### PR TITLE
Enable deterministic builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;NU5104;RCS1001;RCS1123;</NoWarn>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added the Deterministic property to true in Directory.Build.props to ensure builds are reproducible.