### PR TITLE
fix(workflow): inject missing private NuGet API key in build workflow

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -412,3 +412,4 @@ jobs:
           azure-vault-tenant-id: ${{ secrets.AZURE_VAULT_TENANT_ID }}
           azure-vault-app-id: ${{ secrets.AZURE_VAULT_APP_ID }}
           azure-vault-app-secret: ${{ secrets.AZURE_VAULT_APP_SECRET }}
+          private-nuget-api-key: ${{ secrets.PRIVATE_NUGET_API_KEY }}

--- a/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
@@ -462,6 +462,7 @@ public sealed class GithubWorkflowWriter(
             {
                 var injectedSecret = workflow
                     .Options
+                    .Concat(commandStep.Options)
                     .OfType<WorkflowSecretInjection>()
                     .FirstOrDefault(x => x.Param == requiredSecret.Name);
 


### PR DESCRIPTION
Added private-nuget-api-key to secrets in Build.yml and updated GithubWorkflowWriter to ensure key injection.