### PR TITLE
fix(nuget-tool): sanitize feed name, url, and secret

### DIFF
--- a/DecSm.Atom.Tools.Nuget/Commands/NugetAddHandler.cs
+++ b/DecSm.Atom.Tools.Nuget/Commands/NugetAddHandler.cs
@@ -49,7 +49,8 @@ public static class NugetAddHandler
         secret = secret
             ?.Replace("\"", "")
             .Replace("\n", "")
-            .Replace("\r", "");
+            .Replace("\r", "") ??
+                 string.Empty;
 
         Console.WriteLine($"Adding {feed.Name} feed...");
 

--- a/DecSm.Atom.Tools.Nuget/Commands/NugetAddHandler.cs
+++ b/DecSm.Atom.Tools.Nuget/Commands/NugetAddHandler.cs
@@ -39,12 +39,31 @@ public static class NugetAddHandler
             return 0;
         }
 
+        // Sanitize feed name and url
+        var feedName = feed
+            .Name
+            .Replace("\"", "")
+            .Replace("\n", "")
+            .Replace("\r", "");
+
+        var feedUrl = feed
+            .Url
+            .Replace("\"", "")
+            .Replace("\n", "")
+            .Replace("\r", "");
+
         var secret = Environment.GetEnvironmentVariable($"NUGET_TOKEN_{feed.Name.Replace(" ", "_").ToUpper()}");
+
+        // Sanitize secret as it comes from env vars
+        secret = secret
+            ?.Replace("\"", "")
+            .Replace("\n", "")
+            .Replace("\r", "");
 
         Console.WriteLine($"Adding {feed.Name} feed...");
 
         var addSourceProcess = Process.Start(new ProcessStartInfo("dotnet",
-            $"nuget add source --name {feed.Name} --username USERNAME --password {secret} --store-password-in-clear-text {feed.Url}")
+            $"nuget add source --name \"{feedName}\" --username USERNAME --password \"{secret}\" --store-password-in-clear-text \"{feedUrl}\"")
         {
             RedirectStandardError = true,
         })!;

--- a/DecSm.Atom.Tools.Nuget/Commands/NugetAddHandler.cs
+++ b/DecSm.Atom.Tools.Nuget/Commands/NugetAddHandler.cs
@@ -39,22 +39,13 @@ public static class NugetAddHandler
             return 0;
         }
 
-        // Sanitize feed name and url
-        var feedName = feed
-            .Name
-            .Replace("\"", "")
-            .Replace("\n", "")
-            .Replace("\r", "");
-
-        var feedUrl = feed
-            .Url
-            .Replace("\"", "")
-            .Replace("\n", "")
-            .Replace("\r", "");
-
         var secret = Environment.GetEnvironmentVariable($"NUGET_TOKEN_{feed.Name.Replace(" ", "_").ToUpper()}");
 
-        // Sanitize secret as it comes from env vars
+        // Sanitize feed name and url
+        var feedName = new string(feed.Name.Where(c => char.IsLetterOrDigit(c) || c == '-' || c == '_').ToArray());
+        var feedUrl = new string(feed.Url.Where(c => char.IsLetterOrDigit(c) || c == '-' || c == '_' || c == '/' || c == ':' || c == '.').ToArray());
+
+        // Sanitize secret
         secret = secret
             ?.Replace("\"", "")
             .Replace("\n", "")
@@ -62,9 +53,9 @@ public static class NugetAddHandler
 
         Console.WriteLine($"Adding {feed.Name} feed...");
 
-        var addSourceProcess = Process.Start(new ProcessStartInfo("dotnet",
-            $"nuget add source --name \"{feedName}\" --username USERNAME --password \"{secret}\" --store-password-in-clear-text \"{feedUrl}\"")
+        var addSourceProcess = Process.Start(new ProcessStartInfo("dotnet")
         {
+            ArgumentList = { "nuget", "add", "source", "--name", feedName, "--username", "USERNAME", "--password", secret, "--store-password-in-clear-text", feedUrl },
             RedirectStandardError = true,
         })!;
 


### PR DESCRIPTION
Sanitize the feed name, URL, and secret to remove quotation marks and newline characters in the Nuget tool. This prevents potential issues when adding the NuGet source using the dotnet CLI.

Addresses https://github.com/DecSmith42/atom/security/code-scanning/2