### PR TITLE
Alert autofix 1

### DIFF
--- a/DecSm.Atom.Tool/Program.cs
+++ b/DecSm.Atom.Tool/Program.cs
@@ -7,8 +7,22 @@ while (currentDirectory?.Exists is true)
     if (Directory.Exists(Path.Combine(currentDirectory.FullName, "_atom")))
     {
         var atomProjectPath = Path.Combine(currentDirectory.FullName, "_atom", "_atom.csproj");
-        var escapedArgs = args.Select(arg => System.Security.SecurityElement.Escape(arg));
-        var atomProcess = Process.Start("dotnet", $"run --project \"{atomProjectPath}\" {string.Join(" ", escapedArgs)}");
+
+        // Sanitize arguments
+        var escapedArgs = args.Select(arg =>
+        {
+            arg = arg
+                .Replace("\n", string.Empty)
+                .Replace("\r", string.Empty);
+
+            return arg.Contains(';') || arg.Contains('&') || arg.Contains('|') || arg.Contains(' ')
+                ? $"\"{arg}\""
+                : arg;
+        });
+
+        var allArgs = new[] { "run", "--project", atomProjectPath }.Concat(escapedArgs);
+
+        var atomProcess = Process.Start("dotnet", allArgs);
         atomProcess.WaitForExit();
 
         return atomProcess.ExitCode;

--- a/DecSm.Atom.Tool/Program.cs
+++ b/DecSm.Atom.Tool/Program.cs
@@ -7,7 +7,8 @@ while (currentDirectory?.Exists is true)
     if (Directory.Exists(Path.Combine(currentDirectory.FullName, "_atom")))
     {
         var atomProjectPath = Path.Combine(currentDirectory.FullName, "_atom", "_atom.csproj");
-        var atomProcess = Process.Start("dotnet", $"run --project \"{atomProjectPath}\" {string.Join(" ", args)}");
+        var escapedArgs = args.Select(arg => System.Security.SecurityElement.Escape(arg));
+        var atomProcess = Process.Start("dotnet", $"run --project \"{atomProjectPath}\" {string.Join(" ", escapedArgs)}");
         atomProcess.WaitForExit();
 
         return atomProcess.ExitCode;


### PR DESCRIPTION
Sanitized input arguments by removing newlines and surrounding potentially harmful characters with quotes. This prevents injection attacks or unexpected behavior when running the `dotnet` command.

Added logic to filter out newline characters and ensure arguments containing special characters are properly quoted.