### PR TITLE
Address logging and regex security alerts for user inputs in modules

### DIFF
--- a/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
+++ b/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
@@ -48,7 +48,7 @@ public sealed class AzureBlobArtifactProvider(
             if (files.Length == 0)
                 throw new InvalidOperationException($"Could not find any files in the directory {publishDir}");
 
-            logger.LogInformation("Uploading {FileCount} files to {BlobDir}", files.Length, artifactBlobDir);
+            logger.LogInformation("Uploading {FileCount} files to {BlobDir}", files.Length, artifactBlobDir.SanitizeForLogging());
 
             foreach (var file in files)
             {

--- a/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
+++ b/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
@@ -252,8 +252,8 @@ public sealed class AzureBlobArtifactProvider(
         var buildIds = new List<string>();
 
         var blobNameRegex = artifactName is { Length: > 0 }
-            ? new Regex($"^{buildName}/[^/]+/{artifactName}")
-            : new($"^{buildName}/[^/]+/");
+            ? new Regex($"^{Regex.Escape(buildName ?? string.Empty)}/[^/]+/{Regex.Escape(artifactName)}")
+            : new($"^{Regex.Escape(buildName ?? string.Empty)}/[^/]+/");
 
         await foreach (var blob in blobs)
         {

--- a/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
+++ b/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
@@ -28,7 +28,9 @@ public sealed class AzureBlobArtifactProvider(
         var pathSafeRegex = new Regex($"[{Regex.Escape(new(invalidPathChars))}]");
         var matrixSlice = pathSafeRegex.Replace(paramService.GetParam(nameof(IBuildDefinition.MatrixSlice)) ?? string.Empty, "-");
 
-        logger.LogInformation("Uploading artifacts '{Artifacts}' to container '{Container}'", artifactNames, container);
+        logger.LogInformation("Uploading artifacts '{Artifacts}' to container '{Container}'",
+            artifactNames,
+            container.SanitizeForLogging());
 
         foreach (var artifactName in artifactNames)
         {

--- a/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
+++ b/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
@@ -150,7 +150,9 @@ public sealed class AzureBlobArtifactProvider(
         var pathSafeRegex = new Regex($"[{Regex.Escape(new(invalidPathChars))}]");
         var matrixSlice = pathSafeRegex.Replace(paramService.GetParam(nameof(IBuildDefinition.MatrixSlice)) ?? string.Empty, "-");
 
-        logger.LogInformation("Downloading artifact '{Artifacts}' from container '{Container}'", artifactName, container);
+        logger.LogInformation("Downloading artifact '{Artifacts}' from container '{Container}'",
+            artifactName,
+            container.SanitizeForLogging());
 
         foreach (var buildId in buildIds)
         {

--- a/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
+++ b/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
@@ -81,7 +81,9 @@ public sealed class AzureBlobArtifactProvider(
         var pathSafeRegex = new Regex($"[{Regex.Escape(new(invalidPathChars))}]");
         var matrixSlice = pathSafeRegex.Replace(paramService.GetParam(nameof(IBuildDefinition.MatrixSlice)) ?? string.Empty, "-");
 
-        logger.LogInformation("Downloading artifacts '{Artifacts}' from container '{Container}'", artifactNames, container);
+        logger.LogInformation("Downloading artifacts '{Artifacts}' from container '{Container}'",
+            artifactNames,
+            container.SanitizeForLogging());
 
         foreach (var artifactName in artifactNames)
         {

--- a/DecSm.Atom.Module.AzureStorage/_usings.cs
+++ b/DecSm.Atom.Module.AzureStorage/_usings.cs
@@ -6,5 +6,6 @@ global using DecSm.Atom.Build.Definition;
 global using DecSm.Atom.Params;
 global using DecSm.Atom.Paths;
 global using DecSm.Atom.Reports;
+global using DecSm.Atom.Util;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;

--- a/DecSm.Atom.Module.DevopsWorkflows/DevopsVariableProvider.cs
+++ b/DecSm.Atom.Module.DevopsWorkflows/DevopsVariableProvider.cs
@@ -30,7 +30,9 @@ public class DevopsVariableProvider(ILogger<DevopsVariableProvider> logger) : IW
             return Task.FromResult(false);
         }
 
-        logger.LogInformation("Read variable {VariableName} with value {VariableValue} from Azure DevOps pipeline", variableName, value);
+        logger.LogInformation("Read variable {VariableName} with value {VariableValue} from Azure DevOps pipeline",
+            variableName,
+            value.SanitizeForLogging());
 
         return Task.FromResult(true);
     }

--- a/DecSm.Atom.Module.DevopsWorkflows/_usings.cs
+++ b/DecSm.Atom.Module.DevopsWorkflows/_usings.cs
@@ -10,6 +10,7 @@ global using DecSm.Atom.Module.DevopsWorkflows.Triggers;
 global using DecSm.Atom.Params;
 global using DecSm.Atom.Paths;
 global using DecSm.Atom.Reports;
+global using DecSm.Atom.Util;
 global using DecSm.Atom.Variables;
 global using DecSm.Atom.Workflows.Definition;
 global using DecSm.Atom.Workflows.Definition.Command;

--- a/DecSm.Atom/Util/StringUtil.cs
+++ b/DecSm.Atom/Util/StringUtil.cs
@@ -36,4 +36,22 @@ public static class StringUtil
 
         return distance.Span[fromLength * (toLength + 1) + toLength];
     }
+
+    [return: NotNullIfNotNull(nameof(value))]
+    public static string? SanitizeForLogging(this string? value, bool stripNewlines = true, int maxLength = 4096)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        if (stripNewlines)
+            value = value
+                .Replace(Environment.NewLine, " ")
+                .Replace("\r", " ")
+                .Replace("\n", " ");
+
+        if (value.Length <= maxLength)
+            return value;
+
+        return value[..maxLength] + "...";
+    }
 }


### PR DESCRIPTION
Introduced a new SanitizeForLogging method to sanitize strings for logging purposes.
The method strips newlines and truncates strings surpassing a specified max length.

Addresses:
- https://github.com/DecSmith42/atom/security/code-scanning/3
- https://github.com/DecSmith42/atom/security/code-scanning/4
- https://github.com/DecSmith42/atom/security/code-scanning/5
- https://github.com/DecSmith42/atom/security/code-scanning/6
- https://github.com/DecSmith42/atom/security/code-scanning/7
- https://github.com/DecSmith42/atom/security/code-scanning/8
- https://github.com/DecSmith42/atom/security/code-scanning/9