### PR TITLE
feat(build): support more flexible build ID paths for artifact storage

### DIFF
--- a/.devops/workflows/Test_BuildPrivateNugetFeed.yml
+++ b/.devops/workflows/Test_BuildPrivateNugetFeed.yml
@@ -25,6 +25,12 @@ jobs:
       - checkout: self
         fetchDepth: 0
       
+      - script: |
+          dotnet run --project DecSm.Atom.Tools.Nuget/DecSm.Atom.Tools.Nuget.csproj -- nuget-add --feed "DecSm;https://nuget.pkg.github.com/DecSmith42/index.json"
+        displayName: 'Setup NuGet'
+        env:
+          NUGET_TOKEN_DECSM: $(PRIVATE_NUGET_API_KEY)
+        
       - script: dotnet run --project _atom/_atom.csproj TestPrivateNugetRestore --skip --headless
         name: TestPrivateNugetRestore
   
@@ -68,3 +74,4 @@ jobs:
           azure-vault-tenant-id: $(AZURE_VAULT_TENANT_ID)
           azure-vault-app-id: $(AZURE_VAULT_APP_ID)
           azure-vault-app-secret: $(AZURE_VAULT_APP_SECRET)
+          private-nuget-api-key: $(PRIVATE_NUGET_API_KEY)

--- a/.devops/workflows/Test_BuildPrivateNugetFeed.yml
+++ b/.devops/workflows/Test_BuildPrivateNugetFeed.yml
@@ -16,6 +16,8 @@ jobs:
       
       - script: dotnet run --project _atom/_atom.csproj Setup --skip --headless
         name: Setup
+        env:
+          nuget-dry-run: true
   
   - job: TestPrivateNugetRestore
     pool:
@@ -33,6 +35,8 @@ jobs:
         
       - script: dotnet run --project _atom/_atom.csproj TestPrivateNugetRestore --skip --headless
         name: TestPrivateNugetRestore
+        env:
+          nuget-dry-run: true
   
   - job: PackPrivateTestLib
     pool:
@@ -44,6 +48,8 @@ jobs:
       
       - script: dotnet run --project _atom/_atom.csproj PackPrivateTestLib --skip --headless
         name: PackPrivateTestLib
+        env:
+          nuget-dry-run: true
       
       - task: PublishPipelineArtifact@1
         displayName: PrivateTestLib
@@ -75,3 +81,4 @@ jobs:
           azure-vault-app-id: $(AZURE_VAULT_APP_ID)
           azure-vault-app-secret: $(AZURE_VAULT_APP_SECRET)
           private-nuget-api-key: $(PRIVATE_NUGET_API_KEY)
+          nuget-dry-run: true

--- a/.devops/workflows/Test_ValidatePrivateNugetFeed.yml
+++ b/.devops/workflows/Test_ValidatePrivateNugetFeed.yml
@@ -43,5 +43,11 @@ jobs:
       - checkout: self
         fetchDepth: 0
       
+      - script: |
+          dotnet run --project DecSm.Atom.Tools.Nuget/DecSm.Atom.Tools.Nuget.csproj -- nuget-add --feed "DecSm;https://nuget.pkg.github.com/DecSmith42/index.json"
+        displayName: 'Setup NuGet'
+        env:
+          NUGET_TOKEN_DECSM: $(PRIVATE_NUGET_API_KEY)
+        
       - script: dotnet run --project _atom/_atom.csproj TestPrivateNugetRestore --skip --headless
         name: TestPrivateNugetRestore

--- a/.github/workflows/Test_BuildPrivateNugetFeed.yml
+++ b/.github/workflows/Test_BuildPrivateNugetFeed.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Setup
         id: Setup
         run: dotnet run --project _atom/_atom.csproj Setup --skip --headless
+        env:
+          nuget-dry-run: true
   
   TestPrivateNugetRestore:
     runs-on: ubuntu-latest
@@ -42,6 +44,8 @@ jobs:
       - name: TestPrivateNugetRestore
         id: TestPrivateNugetRestore
         run: dotnet run --project _atom/_atom.csproj TestPrivateNugetRestore --skip --headless
+        env:
+          nuget-dry-run: true
   
   PackPrivateTestLib:
     runs-on: ubuntu-latest
@@ -55,6 +59,8 @@ jobs:
       - name: PackPrivateTestLib
         id: PackPrivateTestLib
         run: dotnet run --project _atom/_atom.csproj PackPrivateTestLib --skip --headless
+        env:
+          nuget-dry-run: true
       
       - name: Upload PrivateTestLib
         uses: actions/upload-artifact@v4
@@ -88,3 +94,4 @@ jobs:
           azure-vault-app-id: ${{ secrets.AZURE_VAULT_APP_ID }}
           azure-vault-app-secret: ${{ secrets.AZURE_VAULT_APP_SECRET }}
           private-nuget-api-key: ${{ secrets.PRIVATE_NUGET_API_KEY }}
+          nuget-dry-run: true

--- a/DecSm.Atom.Module.DevopsWorkflows/_usings.cs
+++ b/DecSm.Atom.Module.DevopsWorkflows/_usings.cs
@@ -1,5 +1,6 @@
 global using System.Reflection;
 global using System.Text;
+global using System.Text.RegularExpressions;
 global using DecSm.Atom.Artifacts;
 global using DecSm.Atom.Build;
 global using DecSm.Atom.Build.Definition;
@@ -7,6 +8,7 @@ global using DecSm.Atom.Build.Model;
 global using DecSm.Atom.Module.DevopsWorkflows.Generation;
 global using DecSm.Atom.Module.DevopsWorkflows.Generation.Options;
 global using DecSm.Atom.Module.DevopsWorkflows.Triggers;
+global using DecSm.Atom.Nuget;
 global using DecSm.Atom.Params;
 global using DecSm.Atom.Paths;
 global using DecSm.Atom.Reports;

--- a/DecSm.Atom.Module.GitVersion/GitVersionBuildIdProvider.cs
+++ b/DecSm.Atom.Module.GitVersion/GitVersionBuildIdProvider.cs
@@ -34,4 +34,12 @@ public sealed class GitVersionBuildIdProvider(
             return _buildId = buildId ?? throw new InvalidOperationException("Failed to determine build ID");
         }
     }
+
+    public string GetBuildIdPathPrefix(string buildId)
+    {
+        if (!SemVer.TryParse(buildId, out var version))
+            throw new InvalidOperationException($"Failed to parse build ID '{buildId}' as SemVer");
+
+        return $"{version.Major}/{version.Minor}/{version.Patch}";
+    }
 }

--- a/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
@@ -272,9 +272,9 @@ public sealed class GithubWorkflowWriter(
                         .Append(matrixSlice)
                         .ToArray();
 
-                var allOptions = job.Options.Concat(workflow.Options);
-
-                var setupNugetSteps = allOptions
+                var setupNugetSteps = workflow
+                    .Options
+                    .Concat(commandStep.Options)
                     .OfType<AddNugetFeedsStep>()
                     .ToList();
 

--- a/DecSm.Atom.Tests/Artifacts/DownloadArtifactTests.cs
+++ b/DecSm.Atom.Tests/Artifacts/DownloadArtifactTests.cs
@@ -22,7 +22,7 @@ public class DownloadArtifactTests
             });
 
         A
-            .CallTo(() => artifactProvider.DownloadArtifacts(A<string[]>.That.IsSameSequenceAs(artifactNames), A<string?>._))
+            .CallTo(() => artifactProvider.DownloadArtifacts(A<string[]>.That.IsSameSequenceAs(artifactNames), A<string>.Ignored))
             .Returns(Task.CompletedTask);
 
         var services = new ServiceCollection()
@@ -60,7 +60,7 @@ public class DownloadArtifactTests
             .Tasks[0]();
 
         A
-            .CallTo(() => artifactProvider.DownloadArtifacts(A<string[]>.That.IsSameSequenceAs(artifactNames), A<string?>._))
+            .CallTo(() => artifactProvider.DownloadArtifacts(A<string[]>.That.IsSameSequenceAs(artifactNames), A<string>.Ignored))
             .MustHaveHappenedOnceExactly();
     }
 }

--- a/DecSm.Atom/Artifacts/IDownloadArtifact.cs
+++ b/DecSm.Atom/Artifacts/IDownloadArtifact.cs
@@ -7,6 +7,7 @@ public partial interface IDownloadArtifact : IArtifactHelper
         targetDefinition =>
         {
             var artifactProvider = GetService<IArtifactProvider>();
+            var buildIdProvider = GetService<IBuildIdProvider>();
 
             targetDefinition.IsHidden();
 

--- a/DecSm.Atom/Build/AtomBuildIdProvider.cs
+++ b/DecSm.Atom/Build/AtomBuildIdProvider.cs
@@ -5,4 +5,14 @@ internal sealed class AtomBuildIdProvider : IBuildIdProvider
     private string? _buildId;
 
     public string BuildId => _buildId ??= $"{(DateTimeOffset.UtcNow - DateTimeOffset.UnixEpoch).TotalSeconds:0}";
+
+    public string GetBuildIdPathPrefix(string buildId)
+    {
+        if (!long.TryParse(buildId, out var unixSeconds))
+            throw new InvalidOperationException($"Failed to parse build ID '{buildId}' as Unix seconds");
+
+        var dateTime = DateTimeOffset.FromUnixTimeSeconds(unixSeconds);
+
+        return $"{dateTime.Year}/{dateTime.Month}";
+    }
 }

--- a/DecSm.Atom/Build/IBuildIdProvider.cs
+++ b/DecSm.Atom/Build/IBuildIdProvider.cs
@@ -3,4 +3,7 @@
 public interface IBuildIdProvider
 {
     string? BuildId { get; }
+
+    string? GetBuildIdPathPrefix(string buildId) =>
+        null;
 }

--- a/_atom/Build.cs
+++ b/_atom/Build.cs
@@ -111,6 +111,7 @@ internal partial class Build : BuildDefinition,
                 Commands.PushToPrivateNuget.WithAddedOptions(new WorkflowSecretInjection(Params.PrivateNugetApiKey)),
             ],
             WorkflowTypes = [Github.WorkflowType, Devops.WorkflowType],
+            Options = [new WorkflowParamInjection(Params.NugetDryRun, "true")],
         },
         new("Test_Devops_Validate")
         {


### PR DESCRIPTION
This pull request introduces several changes to the `AzureBlobArtifactProvider` class to improve the handling of build IDs and their paths. These changes ensure that build IDs are more systematically managed and integrated into the artifact upload and download processes.

Key changes include:

### Enhancements to Build ID Handling:

* Added a new dependency `IBuildIdProvider` to the `AzureBlobArtifactProvider` constructor to manage build IDs more effectively (`DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs`).
* Replaced direct calls to `paramService.GetParam` with `buildIdProvider.BuildId` to retrieve the build ID (`DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs`). [[1]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L17-R27) [[2]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L74-R87)
* Introduced the `GetBuildIdPathPrefix` method in `IBuildIdProvider` to generate a path prefix based on the build ID, and used this prefix in various methods to construct paths (`DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs`). [[1]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L17-R27) [[2]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L40-R47) [[3]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L99-R113) [[4]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L159-R184) [[5]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L219-R238)

### Code Refactoring:

* Updated the `DownloadArtifacts` and `DownloadArtifact` methods to use the new build ID path prefix, ensuring consistency in path construction (`DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs`). [[1]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L99-R113) [[2]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L185-R204)
* Modified the `GetStoredBuildIds` method to use a regex that matches the new build ID path format (`DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs`).

### Additional Changes:

* Added the `GetBuildIdPathPrefix` method to `GitVersionBuildIdProvider` and `AtomBuildIdProvider` to provide specific implementations for generating build ID path prefixes (`DecSm.Atom.Module.GitVersion/GitVersionBuildIdProvider.cs`, `DecSm.Atom/Build/AtomBuildIdProvider.cs`). [[1]](diffhunk://#diff-e76e6161fb830c7567c94dffb89a76674935affdfff10859984cb205534fe184R37-R44) [[2]](diffhunk://#diff-df8ef6ad5b00b8f419496aef17dd5ba80f338760c467fabb3ec0911288f1a256R8-R17)
* Updated unit tests to accommodate the changes in the `DownloadArtifacts` method signature (`DecSm.Atom.Tests/Artifacts/DownloadArtifactTests.cs`). [[1]](diffhunk://#diff-5fe1c25b741962dbb5457954bbed3f15927f5047e0f787fc96a0820aabdb588fL25-R25) [[2]](diffhunk://#diff-5fe1c25b741962dbb5457954bbed3f15927f5047e0f787fc96a0820aabdb588fL63-R63)

These changes enhance the maintainability and scalability of the artifact management system by providing a more structured approach to handling build IDs.