### PR TITLE
fix(gitversion): change build ID formatting from slashes to dots

### DIFF
--- a/DecSm.Atom.Module.GitVersion/GitVersionBuildIdProvider.cs
+++ b/DecSm.Atom.Module.GitVersion/GitVersionBuildIdProvider.cs
@@ -40,6 +40,6 @@ public sealed class GitVersionBuildIdProvider(
         if (!SemVer.TryParse(buildId, out var version))
             throw new InvalidOperationException($"Failed to parse build ID '{buildId}' as SemVer");
 
-        return $"{version.Major}/{version.Minor}/{version.Patch}";
+        return $"{version.Major}.{version.Minor}.{version.Patch}";
     }
 }


### PR DESCRIPTION
This pull request includes a small but significant change to the `GetBuildIdPathPrefix` method in the `GitVersionBuildIdProvider.cs` file. The change modifies the format of the returned build ID path prefix.

* [`DecSm.Atom.Module.GitVersion/GitVersionBuildIdProvider.cs`](diffhunk://#diff-e76e6161fb830c7567c94dffb89a76674935affdfff10859984cb205534fe184L43-R43): Changed the delimiter in the build ID path prefix from slashes to dots.