### PR TITLE
fix(build): address missing parameter handling in BuildExecutor

### DIFF
--- a/DecSm.Atom/Build/BuildExecutor.cs
+++ b/DecSm.Atom/Build/BuildExecutor.cs
@@ -63,9 +63,14 @@ internal sealed class BuildExecutor(
                 if (paramDefinition.Attribute.DefaultValue is { Length: > 0 })
                     defaultValue = paramDefinition.Attribute.DefaultValue;
 
-            var value = paramService.GetParam(requirement, defaultValue);
+            var interpolatedDefault = defaultValue is { Length: > 0 } && defaultValue.Contains('{') && defaultValue.Contains('}');
 
-            if (value is { Length: > 0 })
+            var value = paramService.GetParam(requirement,
+                interpolatedDefault
+                    ? null
+                    : defaultValue);
+
+            if (value is { Length: > 0 } || interpolatedDefault)
                 continue;
 
             logger.LogError("Missing required parameter '{ParamName}' for target {TargetDefinitionName}", requirement, target.Name);


### PR DESCRIPTION
Updated BuildExecutor to only provide a default value to GetParam() if it isn't interpolated/dynamic (otherwise an incorrect value will be cached).