### PR TITLE
feat(params): introduce ParamSource enum and enhance filtering

### DIFF
--- a/DecSm.Atom.SourceGenerators/BuildDefinitionSourceGenerator.cs
+++ b/DecSm.Atom.SourceGenerators/BuildDefinitionSourceGenerator.cs
@@ -152,10 +152,11 @@ public class BuildDefinitionSourceGenerator : IIncrementalGenerator
                 AttributeArgs = x
                     .Attribute
                     .ConstructorArguments
-                    .Select(static a => a.Value)
-                    .Select(static a => a is string s
+                    .Select(static a => a.Kind is TypedConstantKind.Enum
+                        ? $"({a.Type!.ToDisplayString()}){a.Value}"
+                        : a.Value is string s
                         ? $"\"{s}\""
-                        : a)
+                        : a.Value)
                     .Select(static a => a ?? "null")
                     .Aggregate(static (a, b) => $"{a}, {b}"),
             })
@@ -193,34 +194,34 @@ public class BuildDefinitionSourceGenerator : IIncrementalGenerator
                      {
                          private System.Collections.Generic.IReadOnlyDictionary<string, {{TargetFull}}>? _targetDefinitions;
                          private System.Collections.Generic.IReadOnlyDictionary<string, {{ParamDefinitionFull}}>? _paramDefinitions;
-                     
+
                          public {{@class}}(System.IServiceProvider services) : base(services) { }
-                     
+
                          public override System.Collections.Generic.IReadOnlyDictionary<string, {{TargetFull}}> TargetDefinitions => _targetDefinitions ??= new System.Collections.Generic.Dictionary<string, {{TargetFull}}>
                          {
                      {{string.Join("\n", targetDefinitionsPropertyBodyLines)}}
                          };
-                     
+
                          public override System.Collections.Generic.IReadOnlyDictionary<string, {{ParamDefinitionFull}}> ParamDefinitions => _paramDefinitions ??= new System.Collections.Generic.Dictionary<string, {{ParamDefinitionFull}}>
                          {
                      {{string.Join("\n", paramDefinitionsPropertyBodyLines)}}
                          };
-                     
+
                          public static class Commands
                          {
                      {{string.Join("\n\n", commandDefsPropertiesLines)}}
                          }
-                     
+
                          public static class Params
                          {
                      {{string.Join("\n\n", paramsPropertiesLines)}}
                          }
-                     
+
                          static void {{IBuildDefinitionFull}}.{{Register}}(Microsoft.Extensions.DependencyInjection.IServiceCollection services)
                          {
                      {{string.Join("\n\n", registerMethodBodyLines)}}
                          }
-                     
+
                          private static void {{RegisterTarget}}<T>(Microsoft.Extensions.DependencyInjection.IServiceCollection services)
                              where T : {{IBuildDefinitionFull}} =>
                              T.{{Register}}(services);

--- a/DecSm.Atom.Tests/Params/ParamServiceTests.cs
+++ b/DecSm.Atom.Tests/Params/ParamServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace DecSm.Atom.Tests.Params;
 
 [TestFixture]
+[NonParallelizable]
 public class ParamServiceTests
 {
     [SetUp]
@@ -17,6 +18,10 @@ public class ParamServiceTests
 
         _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
     }
+
+    [TearDown]
+    public void TearDown() =>
+        Environment.SetEnvironmentVariable("test-param", null);
 
     private IBuildDefinition _buildDefinition;
     private CommandLineArgs _args;
@@ -113,9 +118,6 @@ public class ParamServiceTests
 
         // Assert
         result.ShouldBe("EnvValue");
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("test-param", null);
     }
 
     [Test]
@@ -270,5 +272,319 @@ public class ParamServiceTests
         result2.ShouldBe("DefaultValue2");
         result3.ShouldBe("DefaultValue3");
         result4.ShouldBe("DefaultValue3");
+    }
+
+    [Test]
+    public void GetParam_WithNoneFilter_IncludesNone()
+    {
+        // Arrange
+        var paramDefinition = new ParamDefinition("TestParam", new("test-param", "Test parameter", null, ParamSource.None));
+
+        _args = new(true, [new ParamArg("test-param", "TestParam", "ArgValue")]);
+        Environment.SetEnvironmentVariable("test-param", "EnvValue");
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Params:test-param", "ConfigValue" },
+            })
+            .Build();
+
+        _vaultProviders = [new TestVaultProvider()];
+
+        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        // Act
+        var result = _paramService.GetParam("TestParam", "DefaultValue");
+
+        // Assert
+        result.ShouldBe("DefaultValue");
+    }
+
+    [Test]
+    public void GetParam_WithCommandLineArgsFilter_IncludesCommandLineArgs()
+    {
+        // Arrange
+        var paramDefinition = new ParamDefinition("TestParam", new("test-param", "Test parameter", null, ParamSource.CommandLineArgs));
+
+        _args = new(true, [new ParamArg("test-param", "TestParam", "ArgValue")]);
+        Environment.SetEnvironmentVariable("test-param", "EnvValue");
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Params:test-param", "ConfigValue" },
+            })
+            .Build();
+
+        _vaultProviders = [new TestVaultProvider()];
+
+        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        // Act
+        var result = _paramService.GetParam("TestParam", "DefaultValue");
+
+        // Assert
+        result.ShouldBe("ArgValue");
+    }
+
+    [Test]
+    public void GetParam_WithEnvironmentVariablesFilter_IncludesEnvironmentVariables()
+    {
+        // Arrange
+        var paramDefinition = new ParamDefinition("TestParam", new("test-param", "Test parameter", null, ParamSource.EnvironmentVariables));
+
+        _args = new(true, [new ParamArg("test-param", "TestParam", "ArgValue")]);
+        Environment.SetEnvironmentVariable("test-param", "EnvValue");
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Params:test-param", "ConfigValue" },
+            })
+            .Build();
+
+        _vaultProviders = [new TestVaultProvider()];
+
+        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        // Act
+        var result = _paramService.GetParam("TestParam", "DefaultValue");
+
+        // Assert
+        result.ShouldBe("EnvValue");
+    }
+
+    [Test]
+    public void GetParam_WithConfigurationFilter_IncludesConfiguration()
+    {
+        // Arrange
+        var paramDefinition = new ParamDefinition("TestParam", new("test-param", "Test parameter", null, ParamSource.Configuration));
+
+        _args = new(true, [new ParamArg("test-param", "TestParam", "ArgValue")]);
+        Environment.SetEnvironmentVariable("test-param", "EnvValue");
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Params:test-param", "ConfigValue" },
+            })
+            .Build();
+
+        _vaultProviders = [new TestVaultProvider()];
+
+        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        // Act
+        var result = _paramService.GetParam("TestParam", "DefaultValue");
+
+        // Assert
+        result.ShouldBe("ConfigValue");
+    }
+
+    [Test]
+    public void GetParam_WithVariablesFilter_IncludesCommandLineArgs()
+    {
+        // Arrange
+        var paramDefinition = new ParamDefinition("TestParam", new("test-param", "Test parameter", null, ParamSource.Variables));
+
+        _args = new(true, [new ParamArg("test-param", "TestParam", "ArgValue")]);
+        Environment.SetEnvironmentVariable("test-param", "EnvValue");
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Params:test-param", "ConfigValue" },
+            })
+            .Build();
+
+        _vaultProviders = [new TestVaultProvider()];
+
+        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        // Act
+        var result = _paramService.GetParam("TestParam", "DefaultValue");
+
+        // Assert
+        result.ShouldBe("ArgValue");
+    }
+
+    [Test]
+    public void GetParam_WithVariablesFilter_IncludesEnvironmentVariables()
+    {
+        // Arrange
+        var paramDefinition = new ParamDefinition("TestParam", new("test-param", "Test parameter", null, ParamSource.Variables));
+
+        _args = new(true, [new ParamArg("not-test-param", "NotTestParam", "ArgValue")]);
+        Environment.SetEnvironmentVariable("test-param", "EnvValue");
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Params:test-param", "ConfigValue" },
+            })
+            .Build();
+
+        _vaultProviders = [new TestVaultProvider()];
+
+        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        // Act
+        var result = _paramService.GetParam("TestParam", "DefaultValue");
+
+        // Assert
+        result.ShouldBe("EnvValue");
+    }
+
+    [Test]
+    public void GetParam_WithVariablesFilter_IncludesConfiguration()
+    {
+        // Arrange
+        var paramDefinition = new ParamDefinition("TestParam", new("test-param", "Test parameter", null, ParamSource.Variables));
+
+        _args = new(true, [new ParamArg("not-test-param", "NotTestParam", "ArgValue")]);
+        Environment.SetEnvironmentVariable("not-test-param", "EnvValue");
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Params:test-param", "ConfigValue" },
+            })
+            .Build();
+
+        _vaultProviders = [new TestVaultProvider()];
+
+        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        // Act
+        var result = _paramService.GetParam("TestParam", "DefaultValue");
+
+        // Assert
+        result.ShouldBe("ConfigValue");
+    }
+
+    [Test]
+    public void GetParam_WithVaultFilter_IncludesVault()
+    {
+        // Arrange
+        var paramDefinition = new ParamDefinition("TestParam",
+            new SecretDefinitionAttribute("test-param", "Test parameter", null, ParamSource.Vault));
+
+        _args = new(true, [new ParamArg("test-param", "NotTestParam", "ArgValue")]);
+        Environment.SetEnvironmentVariable("test-param", "EnvValue");
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Params:test-param", "ConfigValue" },
+            })
+            .Build();
+
+        _vaultProviders = [new TestVaultProvider()];
+
+        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        // Act
+        var result = _paramService.GetParam("TestParam", "DefaultValue");
+
+        // Assert
+        result.ShouldBe("VaultValue");
+    }
+
+    [Test]
+    public void GetParam_WithSecretsFilter_IncludesVault()
+    {
+        // Arrange
+        var paramDefinition = new ParamDefinition("TestParam",
+            new SecretDefinitionAttribute("test-param", "Test parameter", null, ParamSource.Vault));
+
+        _args = new(true, [new ParamArg("test-param", "TestParam", "ArgValue")]);
+        Environment.SetEnvironmentVariable("test-param", "EnvValue");
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "Params:test-param", "ConfigValue" },
+            })
+            .Build();
+
+        _vaultProviders = [new TestVaultProvider()];
+
+        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        // Act
+        var result = _paramService.GetParam("TestParam", "DefaultValue");
+
+        // Assert
+        result.ShouldBe("VaultValue");
+    }
+
+    private class TestVaultProvider : IVaultProvider
+    {
+        public string GetSecret(string secretName) =>
+            "VaultValue";
     }
 }

--- a/DecSm.Atom.Tool/Program.cs
+++ b/DecSm.Atom.Tool/Program.cs
@@ -21,7 +21,8 @@ var result = await new CommandLineBuilder(new RootCommand
             urlOption,
         }.WithHandler(NugetAddHandler.Handle, new NugetAddOptionsBinder(nameOption, urlOption), cancelTokenValueSource),
     }.WithHandler(RunHandler.Handle, RunArgsBinder.Instance, new ProjectOptionBinder(projectOption), cancelTokenValueSource))
-    .UseDefaults()
+    .UseParseErrorReporting()
+    .UseExceptionHandler()
     .CancelOnProcessTermination()
     .Build()
     .InvokeAsync(args);

--- a/DecSm.Atom.Tool/Program.cs
+++ b/DecSm.Atom.Tool/Program.cs
@@ -18,6 +18,7 @@ var result = await new CommandLineBuilder(new RootCommand
         new Command("nuget-add")
         {
             nameOption,
+            urlOption,
         }.WithHandler(NugetAddHandler.Handle, new NugetAddOptionsBinder(nameOption, urlOption), cancelTokenValueSource),
     }.WithHandler(RunHandler.Handle, RunArgsBinder.Instance, new ProjectOptionBinder(projectOption), cancelTokenValueSource))
     .UseDefaults()

--- a/DecSm.Atom/Params/ParamDefinitionAttribute.cs
+++ b/DecSm.Atom/Params/ParamDefinitionAttribute.cs
@@ -2,13 +2,20 @@
 
 [PublicAPI]
 [AttributeUsage(AttributeTargets.Property)]
-public class ParamDefinitionAttribute(string argName, string description, string? defaultValue = null) : Attribute
+public class ParamDefinitionAttribute(
+    string argName,
+    string description,
+    string? defaultValue = null,
+    ParamSource sources = ParamSource.All
+) : Attribute
 {
     public string ArgName => argName;
 
     public string Description => description;
 
     public string? DefaultValue => defaultValue;
+
+    public ParamSource Sources => sources;
 
     public bool IsSecret { get; protected init; }
 }

--- a/DecSm.Atom/Params/ParamSource.cs
+++ b/DecSm.Atom/Params/ParamSource.cs
@@ -1,0 +1,18 @@
+﻿namespace DecSm.Atom.Params;
+
+[PublicAPI]
+[Flags]
+public enum ParamSource
+{
+    None = 0,
+    Cache = 1,
+    CommandLineArgs = 2,
+    EnvironmentVariables = 4,
+    Configuration = 8,
+    Variables = CommandLineArgs | EnvironmentVariables | Configuration,
+    UserSecrets = 16,
+    Vault = 32,
+    Secrets = UserSecrets | Vault,
+    NoCache = Variables | Secrets,
+    All = Cache | CommandLineArgs | EnvironmentVariables | Configuration | UserSecrets | Vault,
+}

--- a/DecSm.Atom/Params/SecretDefinitionAttribute.cs
+++ b/DecSm.Atom/Params/SecretDefinitionAttribute.cs
@@ -3,9 +3,8 @@ namespace DecSm.Atom.Params;
 [PublicAPI]
 public class SecretDefinitionAttribute : ParamDefinitionAttribute
 {
-    public SecretDefinitionAttribute(string argName, string description, string? defaultValue = null) : base(argName,
-        description,
-        defaultValue)
+    public SecretDefinitionAttribute(string argName, string description, string? defaultValue = null, ParamSource sources = ParamSource.All)
+        : base(argName, description, defaultValue, sources)
     {
         IsSecret = true;
     }


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality and flexibility of parameter handling in the `DecSm.Atom` project. The most significant updates include the addition of new parameter sources, improvements in test coverage, and the refactoring of existing methods to support the new sources.

### Enhancements to Parameter Handling:

* **Support for Multiple Parameter Sources**:
  - Introduced `ParamSource` enum with various sources such as `Cache`, `CommandLineArgs`, `EnvironmentVariables`, `Configuration`, `UserSecrets`, and `Vault`. (`DecSm.Atom/Params/ParamSource.cs`)
  - Updated `ParamDefinitionAttribute` and `SecretDefinitionAttribute` to include the new `ParamSource` parameter. (`DecSm.Atom/Params/ParamDefinitionAttribute.cs`) [[1]](diffhunk://#diff-8047bb76fb32cde784091f7463d8f1a1dab6c5b1565af5f246a1d7d67d47be38L5-R19) (`DecSm.Atom/Params/SecretDefinitionAttribute.cs`) [[2]](diffhunk://#diff-d1e411eaddf97f88427ce55386506e37a3fff9b019fdcb829632870c3835abcfL6-R7)

* **Refactoring of Parameter Retrieval Logic**:
  - Refactored `GetParam` method to check for parameter values across multiple sources based on the defined `ParamSource` flags. (`DecSm.Atom/Params/ParamService.cs`)
  - Simplified the caching logic and removed redundant cache checks. (`DecSm.Atom/Params/ParamService.cs`) [[1]](diffhunk://#diff-0c40242605d992515cab81b9bb1230373f81aea228d162ae3ded16e0827f37ddL135-L158) [[2]](diffhunk://#diff-0c40242605d992515cab81b9bb1230373f81aea228d162ae3ded16e0827f37ddL172-R171) [[3]](diffhunk://#diff-0c40242605d992515cab81b9bb1230373f81aea228d162ae3ded16e0827f37ddL194-R189) [[4]](diffhunk://#diff-0c40242605d992515cab81b9bb1230373f81aea228d162ae3ded16e0827f37ddL216-L218)

### Improvements in Tests:

* **Enhanced Test Coverage**:
  - Added new test cases to verify parameter retrieval from different sources such as `None`, `CommandLineArgs`, `EnvironmentVariables`, `Configuration`, `Variables`, and `Vault`. (`DecSm.Atom.Tests/Params/ParamServiceTests.cs`)
  - Introduced `[NonParallelizable]` attribute to `ParamServiceTests` to prevent parallel execution issues. (`DecSm.Atom.Tests/Params/ParamServiceTests.cs`)
  - Added `[TearDown]` method to clean up environment variables after each test. (`DecSm.Atom.Tests/Params/ParamServiceTests.cs`)

### Code Improvements:

* **Improved Enum Handling**:
  - Updated the `GeneratePartial` method to handle enum types correctly when generating attribute arguments. (`DecSm.Atom.SourceGenerators/BuildDefinitionSourceGenerator.cs`)Added a new ParamSource enum to define sources from which parameters can be loaded.

Enhanced ParamDefinitionAttribute to include a new sources property, allowing more granular control over parameter sourcing.

Updated ParamService to utilize the sources for parameter retrieval, implementing logical checks for different ParamSource flags such as Cache, CommandLineArgs, EnvironmentVariables, Configuration, UserSecrets, and Vault.

Additionally, added more comprehensive unit tests to validate the different parameter sources and refactored some internal logic to simplify caching mechanisms.