### PR TITLE
fix(tests): Fixed tests for non-windows platforms

### DIFF
--- a/DecSm.Atom.Tests/BuildTests/FileSystem/FileSystemTests.cs
+++ b/DecSm.Atom.Tests/BuildTests/FileSystem/FileSystemTests.cs
@@ -14,9 +14,15 @@ public sealed class FileSystemTests
         var atomRootDirectory = atomFileSystem.AtomRootDirectory;
 
         // Assert
+        #if Win32NT
         atomRootDirectory
             .ToString()
             .ShouldBe(@"C:\Atom\_atom");
+        #else
+        atomRootDirectory
+            .ToString()
+            .ShouldBe(@"/Atom/_atom");
+        #endif
     }
 
     [Test]
@@ -29,7 +35,11 @@ public sealed class FileSystemTests
                 Locator = (key, _) => key is AtomPaths.Root
                     ? provider
                         .GetRequiredService<IAtomFileSystem>()
+                        #if Win32NT
                         .CreateAbsolutePath(@"C:\CustomAtomRoot")
+                        #else
+                        .CreateAbsolutePath(@"/CustomAtomRoot")
+                        #endif
                     : null,
                 Priority = 0,
             }));
@@ -39,9 +49,15 @@ public sealed class FileSystemTests
         var atomRootDirectory = atomFileSystem.AtomRootDirectory;
 
         // Assert
+        #if Win32NT
         atomRootDirectory
             .ToString()
             .ShouldBe(@"C:\CustomAtomRoot");
+        #else
+        atomRootDirectory
+            .ToString()
+            .ShouldBe(@"/CustomAtomRoot");
+        #endif
     }
 
     [Test]
@@ -55,9 +71,15 @@ public sealed class FileSystemTests
         var atomRootDirectory = atomFileSystem.AtomArtifactsDirectory;
 
         // Assert
+        #if Win32NT
         atomRootDirectory
             .ToString()
             .ShouldBe(@"C:\Atom\_atom\atom-publish");
+        #else
+        atomRootDirectory
+            .ToString()
+            .ShouldBe(@"/Atom/_atom/atom-publish");
+        #endif
     }
 
     [Test]
@@ -70,7 +92,11 @@ public sealed class FileSystemTests
                 Locator = (key, _) => key is AtomPaths.Artifacts
                     ? provider
                         .GetRequiredService<IAtomFileSystem>()
+                        #if Win32NT
                         .CreateAbsolutePath(@"C:\CustomAtomArtifacts")
+                        #else
+                        .CreateAbsolutePath(@"/CustomAtomArtifacts")
+                        #endif
                     : null,
                 Priority = 0,
             }));
@@ -80,9 +106,15 @@ public sealed class FileSystemTests
         var atomRootDirectory = atomFileSystem.AtomArtifactsDirectory;
 
         // Assert
+        #if Win32NT
         atomRootDirectory
             .ToString()
             .ShouldBe(@"C:\CustomAtomArtifacts");
+        #else
+        atomRootDirectory
+            .ToString()
+            .ShouldBe(@"/CustomAtomArtifacts");
+        #endif
     }
 
     [Test]
@@ -96,9 +128,15 @@ public sealed class FileSystemTests
         var atomRootDirectory = atomFileSystem.AtomPublishDirectory;
 
         // Assert
+        #if Win32NT
         atomRootDirectory
             .ToString()
             .ShouldBe(@"C:\Atom\_atom\atom-publish");
+        #else
+        atomRootDirectory
+            .ToString()
+            .ShouldBe(@"/Atom/_atom/atom-publish");
+        #endif
     }
 
     [Test]
@@ -111,7 +149,11 @@ public sealed class FileSystemTests
                 Locator = (key, _) => key is AtomPaths.Publish
                     ? provider
                         .GetRequiredService<IAtomFileSystem>()
+                        #if Win32NT
                         .CreateAbsolutePath(@"C:\CustomAtomPublish")
+                        #else
+                        .CreateAbsolutePath(@"/CustomAtomPublish")
+                        #endif
                     : null,
                 Priority = 0,
             }));
@@ -121,9 +163,15 @@ public sealed class FileSystemTests
         var atomRootDirectory = atomFileSystem.AtomPublishDirectory;
 
         // Assert
+        #if Win32NT
         atomRootDirectory
             .ToString()
             .ShouldBe(@"C:\CustomAtomPublish");
+        #else
+        atomRootDirectory
+            .ToString()
+            .ShouldBe(@"/CustomAtomPublish");
+        #endif
     }
 
     [Test]
@@ -137,9 +185,15 @@ public sealed class FileSystemTests
         var atomRootDirectory = atomFileSystem.AtomTempDirectory;
 
         // Assert
+        #if Win32NT
         atomRootDirectory
             .ToString()
             .ShouldBe(@"C:\temp");
+        #else
+        atomRootDirectory
+            .ToString()
+            .ShouldBe(@"/temp");
+        #endif
     }
 
     [Test]
@@ -152,7 +206,11 @@ public sealed class FileSystemTests
                 Locator = (key, _) => key is AtomPaths.Temp
                     ? provider
                         .GetRequiredService<IAtomFileSystem>()
+                        #if Win32NT
                         .CreateAbsolutePath(@"C:\CustomAtomTemp")
+                        #else
+                        .CreateAbsolutePath(@"/CustomAtomTemp")
+                        #endif
                     : null,
                 Priority = 0,
             }));
@@ -162,8 +220,14 @@ public sealed class FileSystemTests
         var atomRootDirectory = atomFileSystem.AtomTempDirectory;
 
         // Assert
+        #if Win32NT
         atomRootDirectory
             .ToString()
             .ShouldBe(@"C:\CustomAtomTemp");
+        #else
+        atomRootDirectory
+            .ToString()
+            .ShouldBe(@"/CustomAtomTemp");
+        #endif
     }
 }

--- a/DecSm.Atom.Tests/Utils/TestUtils.cs
+++ b/DecSm.Atom.Tests/Utils/TestUtils.cs
@@ -13,12 +13,21 @@ public static class TestUtils
 
         console ??= new();
 
+        #if Win32NT
         fileSystem ??= new(new Dictionary<string, MockFileData>
             {
-                { @"C:\Atom\Atom.sln", new(string.Empty) },
-                { @"C:\Atom\_atom\_atom.csproj", new(string.Empty) },
+                { @$"C:\Atom\Atom.sln", new(string.Empty) },
+                { @$"C:\Atom\_atom\_atom.csproj", new(string.Empty) },
             },
-            @"C:\Atom\_atom");
+            @$"C:\Atom\_atom");
+        #else
+        fileSystem ??= new(new Dictionary<string, MockFileData>
+            {
+                { @"/Atom/Atom.sln", new(string.Empty) },
+                { @"/Atom/_atom/_atom.csproj", new(string.Empty) },
+            },
+            @"/Atom/_atom");
+        #endif
 
         commandLineArgs ??= new(true, []);
 


### PR DESCRIPTION
This pull request introduces platform-specific path handling in the `DecSm.Atom.Tests` project to ensure compatibility with both Windows and Unix-based systems. The changes primarily involve conditional compilation to handle file paths appropriately based on the operating system.

Platform-specific path handling:

* [`DecSm.Atom.Tests/BuildTests/FileSystem/FileSystemTests.cs`](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R17-R25): Added conditional compilation directives to handle file paths for various test methods, ensuring compatibility with both Windows and Unix-based systems. [[1]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R17-R25) [[2]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R38-R42) [[3]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R52-R60) [[4]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R74-R82) [[5]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R95-R99) [[6]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R109-R117) [[7]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R131-R139) [[8]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R152-R156) [[9]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R166-R174) [[10]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R188-R196) [[11]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R209-R213) [[12]](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74R223-R231)

* [`DecSm.Atom.Tests/Utils/TestUtils.cs`](diffhunk://#diff-0ea7adf942e129085d6a700ec011f9ec9adf8a3d82297bf6bc008c892be69341R16-R30): Added conditional compilation directives to handle file paths in the `CreateTestHost` method, ensuring compatibility with both Windows and Unix-based systems.