### PR TITLE
feat(tests): add tests for default build and console definitions

### DIFF
--- a/DecSm.Atom.Tests/BuildTests/BuildModel/BuildModelTests.BuildModel_DefaultBuildDefinition_HasDefaultTargets.verified.txt
+++ b/DecSm.Atom.Tests/BuildTests/BuildModel/BuildModelTests.BuildModel_DefaultBuildDefinition_HasDefaultTargets.verified.txt
@@ -1,0 +1,45 @@
+﻿{
+  Targets: [
+    {
+      Name: SetupBuildInfo,
+      Description: Sets up the build ID and version,
+      IsHidden: true,
+      Tasks: [
+        {
+          Type: Func<Task>,
+          Target: ISetupBuildInfo,
+          Method: System.Threading.Tasks.Task get_SetupBuildInfo()
+        }
+      ],
+      RequiredParams: [
+        AtomBuildName
+      ],
+      ProducedVariables: [
+        AtomBuildId,
+        AtomBuildVersion
+      ]
+    },
+    {
+      Name: ValidateBuild,
+      Description: Checks the atom build for common issues.,
+      IsHidden: false,
+      Tasks: [
+        {
+          Type: Func<Task>,
+          Target: IValidateBuild,
+          Method: System.Threading.Tasks.Task get_ValidateBuild()
+        }
+      ]
+    }
+  ],
+  TargetStates: {
+    TargetModel { Name = SetupBuildInfo, Description = Sets up the build ID and version, IsHidden = True, Tasks = System.Collections.Generic.List`1[System.Func`1[System.Threading.Tasks.Task]], RequiredParams = System.Collections.Generic.List`1[System.String], ConsumedArtifacts = System.Collections.Generic.List`1[DecSm.Atom.Build.Definition.ConsumedArtifact], ProducedArtifacts = System.Collections.Generic.List`1[DecSm.Atom.Build.Definition.ProducedArtifact], ConsumedVariables = System.Collections.Generic.List`1[DecSm.Atom.Build.Definition.ConsumedVariable], ProducedVariables = System.Collections.Generic.List`1[System.String], Dependencies = System.Collections.Generic.List`1[DecSm.Atom.Build.Model.TargetModel] }: {
+      Name: SetupBuildInfo,
+      Status: Skipped
+    },
+    TargetModel { Name = ValidateBuild, Description = Checks the atom build for common issues., IsHidden = False, Tasks = System.Collections.Generic.List`1[System.Func`1[System.Threading.Tasks.Task]], RequiredParams = System.Collections.Generic.List`1[System.String], ConsumedArtifacts = System.Collections.Generic.List`1[DecSm.Atom.Build.Definition.ConsumedArtifact], ProducedArtifacts = System.Collections.Generic.List`1[DecSm.Atom.Build.Definition.ProducedArtifact], ConsumedVariables = System.Collections.Generic.List`1[DecSm.Atom.Build.Definition.ConsumedVariable], ProducedVariables = System.Collections.Generic.List`1[System.String], Dependencies = System.Collections.Generic.List`1[DecSm.Atom.Build.Model.TargetModel] }: {
+      Name: ValidateBuild,
+      Status: Skipped
+    }
+  }
+}

--- a/DecSm.Atom.Tests/BuildTests/BuildModel/BuildModelTests.cs
+++ b/DecSm.Atom.Tests/BuildTests/BuildModel/BuildModelTests.cs
@@ -17,4 +17,17 @@ public class BuildModelTests
             b => b.TargetStates.ShouldBeEmpty(),
             b => b.CurrentTarget.ShouldBeNull());
     }
+
+    [Test]
+    public async Task BuildModel_DefaultBuildDefinition_HasDefaultTargets()
+    {
+        // Arrange
+        var host = CreateTestHost<DefaultAtomBuild>();
+
+        // Act
+        var buildModel = host.Services.GetRequiredService<Build.Model.BuildModel>();
+
+        // Assert
+        await Verify(buildModel);
+    }
 }

--- a/DecSm.Atom.Tests/BuildTests/Console/ConsoleTests.ConsoleBuildDefinition_Displays_DefaultConsoleMessage.verified.txt
+++ b/DecSm.Atom.Tests/BuildTests/Console/ConsoleTests.ConsoleBuildDefinition_Displays_DefaultConsoleMessage.verified.txt
@@ -1,0 +1,28 @@
+﻿
+Usage
+
+atom [options]
+atom [command/s] [parameters] [options]
+
+Options
+
+  -h,  --help      Show help
+  -g,  --gen       Generate build script
+  -s,  --skip      Skip dependency execution
+  -hl, --headless  Run in headless mode
+  -v,  --verbose   Show verbose output
+
+Atom Commands
+
+ValidateBuild | Checks the atom build for common issues.
+
+Project Commands
+
+ConsoleTarget | Console target
+├── Requires
+│   └── --required-param | Required param
+├── Options
+│   └── --default-param | Default param
+└── Secrets
+    └── --secret-param | Secret param
+

--- a/DecSm.Atom.Tests/BuildTests/Console/ConsoleTests.cs
+++ b/DecSm.Atom.Tests/BuildTests/Console/ConsoleTests.cs
@@ -1,5 +1,29 @@
 ﻿namespace DecSm.Atom.Tests.BuildTests.Console;
 
+[BuildDefinition]
+public partial class ConsoleBuild : DefaultBuildDefinition, IConsoleTarget;
+
+[TargetDefinition]
+public partial interface IConsoleTarget
+{
+    [ParamDefinition("required-param", "Required param")]
+    string RequiredParam => GetParam(() => RequiredParam)!;
+
+    [ParamDefinition("default-param", "Default param", "default-value")]
+    string DefaultParam => GetParam(() => DefaultParam, "default-value");
+
+    [SecretDefinition("secret-param", "Secret param")]
+    string SecretParam => GetParam(() => SecretParam)!;
+
+    Target ConsoleTarget =>
+        d => d
+            .WithDescription("Console target")
+            .RequiresParam(nameof(RequiredParam))
+            .RequiresParam(nameof(DefaultParam))
+            .RequiresParam(nameof(SecretParam))
+            .Executes(() => Task.CompletedTask);
+}
+
 [TestFixture]
 public class ConsoleTests
 {
@@ -23,6 +47,20 @@ public class ConsoleTests
         // Arrange
         var testConsole = new TestConsole();
         var host = CreateTestHost<DefaultAtomBuild>(testConsole);
+
+        // Act
+        await host.RunAsync();
+
+        // Assert
+        await Verify(testConsole.Output);
+    }
+
+    [Test]
+    public async Task ConsoleBuildDefinition_Displays_DefaultConsoleMessage()
+    {
+        // Arrange
+        var testConsole = new TestConsole();
+        var host = CreateTestHost<ConsoleBuild>(testConsole);
 
         // Act
         await host.RunAsync();

--- a/DecSm.Atom/Cheatsheet/CheatsheetService.cs
+++ b/DecSm.Atom/Cheatsheet/CheatsheetService.cs
@@ -142,7 +142,13 @@ internal sealed class CheatsheetService(
             var reqTree = tree.AddNode("[dim bold red]Requires[/]");
 
             foreach (var requiredParam in requiredParams)
-                reqTree.AddNode($"--{requiredParam.Attribute.ArgName} [dim][[{requiredParam.Attribute.Description}]][/]");
+            {
+                var descriptionDisplay = requiredParam.Attribute.Description is { Length: > 0 }
+                    ? $"[dim] | {requiredParam.Attribute.Description}[/]"
+                    : string.Empty;
+
+                reqTree.AddNode($"--{requiredParam.Attribute.ArgName}{descriptionDisplay}");
+            }
         }
 
         if (optionalParams.Count > 0)
@@ -159,14 +165,18 @@ internal sealed class CheatsheetService(
                 var defaultDisplay = (defaultValue, configuredValue) switch
                 {
                     ({ Length: > 0 }, { Length: > 0 }) when defaultValue == configuredValue =>
-                        $"[dim][[Default/Configured: {defaultValue}]][/]",
-                    ({ Length: > 0 }, { Length: > 0 }) => $"[dim][[Default: {defaultValue}]][/][dim][[Configured: {configuredValue}]][/]",
-                    ({ Length: > 0 }, { Length: 0 }) => $"[dim][[Default: {defaultValue}]][/]",
-                    ({ Length: 0 }, { Length: > 0 }) => $"[dim][[Configured: {configuredValue}]][/]",
+                        $"[dim] [[Default/Configured: {defaultValue}]][/]",
+                    ({ Length: > 0 }, { Length: > 0 }) => $"[dim] [[Default: {defaultValue}]][/][dim][[Configured: {configuredValue}]][/]",
+                    ({ Length: > 0 }, { Length: 0 }) => $"[dim] [[Default: {defaultValue}]][/]",
+                    ({ Length: 0 }, { Length: > 0 }) => $"[dim] [[Configured: {configuredValue}]][/]",
                     _ => string.Empty,
                 };
 
-                optTree.AddNode($"--{optionalParam.Attribute.ArgName} {defaultDisplay}");
+                var descriptionDisplay = optionalParam.Attribute.Description is { Length: > 0 }
+                    ? $"[dim] | {optionalParam.Attribute.Description}[/]"
+                    : string.Empty;
+
+                optTree.AddNode($"--{optionalParam.Attribute.ArgName}{defaultDisplay}{descriptionDisplay}");
             }
         }
 
@@ -175,7 +185,13 @@ internal sealed class CheatsheetService(
             var secTree = tree.AddNode("[dim bold purple]Secrets[/]");
 
             foreach (var secret in secrets)
-                secTree.AddNode($"--{secret.Attribute.ArgName}");
+            {
+                var descriptionDisplay = secret.Attribute.Description is { Length: > 0 }
+                    ? $"[dim] | {secret.Attribute.Description}[/]"
+                    : string.Empty;
+
+                secTree.AddNode($"--{secret.Attribute.ArgName}{descriptionDisplay}");
+            }
         }
 
         console.Write(tree);


### PR DESCRIPTION
Introduced tests for the default build definition to ensure it has the default targets set up. Also, added a test for the console build definition to verify that the default console message displays correctly.

Updated the CheatsheetService to enhance parameter description display in the console output.

---

This pull request includes several changes to the `DecSm.Atom` project, primarily focusing on adding new build and console targets, updating test cases, and improving the display of command descriptions in the cheatsheet service.

### Additions to Build and Console Targets:

* Added a new build target `SetupBuildInfo` and `ValidateBuild` to the default build definition in `BuildModelTests.BuildModel_DefaultBuildDefinition_HasDefaultTargets.verified.txt`.
* Introduced a new test `BuildModel_DefaultBuildDefinition_HasDefaultTargets` in `BuildModelTests.cs` to verify the default build targets.
* Added a new console build definition `ConsoleBuild` with a target `ConsoleTarget` in `ConsoleTests.cs`.

### Updates to Test Cases:

* Added a new test `ConsoleBuildDefinition_Displays_DefaultConsoleMessage` to verify the console output for the new console build definition in `ConsoleTests.cs`.
* Updated the verified console output to include new commands and options in `ConsoleTests.ConsoleBuildDefinition_Displays_DefaultConsoleMessage.verified.txt`.

### Improvements to Cheatsheet Service:

* Enhanced the display of required parameters, optional parameters, and secrets by including their descriptions in `CheatsheetService.cs` [[1]](diffhunk://#diff-c8a3f71f3d9bf90fd50dd5e2388938b9efc3c51efdde27c3b8750f57c4e41350L145-R151) [[2]](diffhunk://#diff-c8a3f71f3d9bf90fd50dd5e2388938b9efc3c51efdde27c3b8750f57c4e41350L169-R179) [[3]](diffhunk://#diff-c8a3f71f3d9bf90fd50dd5e2388938b9efc3c51efdde27c3b8750f57c4e41350L178-R194).