### PR TITLE
fix(azure-artifacts): Account for slice in retrieve path

### DIFF
--- a/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
+++ b/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
@@ -126,8 +126,8 @@ public sealed class AzureBlobArtifactProvider(
                 var blobDownloadInfo = await blobClient.DownloadAsync();
                 var blobName = blobItem.Blob.Name;
 
-                if (blobName.StartsWith($"{buildName}/{buildIdPath}/{artifactName}/"))
-                    blobName = blobName[$"{buildName}/{buildIdPath}/{artifactName}/".Length..];
+                if (blobName.StartsWith(artifactBlobDir))
+                    blobName = blobName[artifactBlobDir.Length..];
                 else
                     throw new InvalidOperationException($"Blob name {blobName} does not start with {buildName}/{buildIdPath}");
 
@@ -197,8 +197,8 @@ public sealed class AzureBlobArtifactProvider(
                 var blobDownloadInfo = await blobClient.DownloadAsync();
                 var blobName = blobItem.Blob.Name;
 
-                if (blobName.StartsWith($"{buildName}/{buildIdPath}/{artifactName}/"))
-                    blobName = blobName[$"{buildName}/{buildIdPath}/{artifactName}/".Length..];
+                if (blobName.StartsWith(artifactBlobDir))
+                    blobName = blobName[artifactBlobDir.Length..];
                 else
                     throw new InvalidOperationException($"Blob name {blobName} does not start with {buildName}/{buildIdPath}");
 


### PR DESCRIPTION
This pull request includes changes to the `DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs` file to simplify the logic for extracting the blob name in two methods.

Simplification of blob name extraction:

* `public async Task RetrieveArtifacts(IReadOnlyList<string> artifactNames, string?` method: Changed the condition to check if the blob name starts with `artifactBlobDir` and adjusted the substring extraction accordingly.
* `public async Task RetrieveArtifact(string artifactName, IReadOnlyList<string> ru` method: Applied the same change as above to ensure consistency in blob name extraction.