### PR TITLE
fix(tests): OS-agnostic paths for github workflow tests

### DIFF
--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs
@@ -14,11 +14,18 @@ public class WorkflowTests
         build.Run();
 
         // Assert
-        fileSystem
-            .DirectoryInfo
-            .New(@"C:\Atom\_atom\.github\workflows")
-            .Exists
-            .ShouldBeFalse();
+        if (Environment.OSVersion.Platform is PlatformID.Win32NT)
+            fileSystem
+                .DirectoryInfo
+                .New(@"C:\Atom\_atom\.github\workflows")
+                .Exists
+                .ShouldBeFalse();
+        else
+            fileSystem
+                .DirectoryInfo
+                .New("/Atom/_atom/.github/workflows")
+                .Exists
+                .ShouldBeFalse();
     }
 
     [Test]
@@ -32,13 +39,23 @@ public class WorkflowTests
         await build.RunAsync();
 
         // Assert
-        fileSystem
-            .DirectoryInfo
-            .New(@"C:\Atom\_atom\.github\workflows")
-            .Exists
-            .ShouldBeTrue();
+        if (Environment.OSVersion.Platform is PlatformID.Win32NT)
+            fileSystem
+                .DirectoryInfo
+                .New(@"C:\Atom\_atom\.github\workflows")
+                .Exists
+                .ShouldBeTrue();
+        else
+            fileSystem
+                .DirectoryInfo
+                .New("/Atom/_atom/.github/workflows")
+                .Exists
+                .ShouldBeTrue();
 
-        var workflow = await fileSystem.File.ReadAllTextAsync(@"C:\Atom\_atom\.github\workflows\simple-build.yml");
+        var workflow = Environment.OSVersion.Platform is PlatformID.Win32NT
+            ? await fileSystem.File.ReadAllTextAsync(@"C:\Atom\_atom\.github\workflows\simple-build.yml")
+            : await fileSystem.File.ReadAllTextAsync("/Atom/_atom/.github/workflows/simple-build.yml");
+
         await Verify(workflow);
         await TestContext.Out.WriteAsync(workflow);
     }
@@ -54,13 +71,23 @@ public class WorkflowTests
         await build.RunAsync();
 
         // Assert
-        fileSystem
-            .DirectoryInfo
-            .New(@"C:\Atom\_atom\.github\workflows")
-            .Exists
-            .ShouldBeTrue();
+        if (Environment.OSVersion.Platform is PlatformID.Win32NT)
+            fileSystem
+                .DirectoryInfo
+                .New(@"C:\Atom\_atom\.github\workflows")
+                .Exists
+                .ShouldBeTrue();
+        else
+            fileSystem
+                .DirectoryInfo
+                .New("/Atom/_atom/.github/workflows")
+                .Exists
+                .ShouldBeTrue();
 
-        var workflow = await fileSystem.File.ReadAllTextAsync(@"C:\Atom\_atom\.github\workflows\dependent-build.yml");
+        var workflow = Environment.OSVersion.Platform is PlatformID.Win32NT
+            ? await fileSystem.File.ReadAllTextAsync(@"C:\Atom\_atom\.github\workflows\dependent-build.yml")
+            : await fileSystem.File.ReadAllTextAsync("/Atom/_atom/.github/workflows/dependent-build.yml");
+
         await Verify(workflow);
         await TestContext.Out.WriteAsync(workflow);
     }


### PR DESCRIPTION
This pull request includes changes to the `WorkflowTests.cs` file to handle different operating systems in the test assertions. The main changes involve adding conditional checks for Windows and non-Windows platforms when verifying the existence of directories and reading workflow files.

Platform-specific test adjustments:

* [`DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs`](diffhunk://#diff-3982d3fccc6e45bbae3b7919965f6fca0f4405853a9223f4ffd64d2daaace0c2R17-R28): Modified `MinimalBuild_GeneratesNoWorkflows` to check the existence of the `.github/workflows` directory conditionally based on the operating system.
* [`DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs`](diffhunk://#diff-3982d3fccc6e45bbae3b7919965f6fca0f4405853a9223f4ffd64d2daaace0c2R42-L41): Updated `SimpleBuild_GeneratesWorkflow` to conditionally check the existence of the `.github/workflows` directory and read the workflow file based on the operating system.
* [`DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs`](diffhunk://#diff-3982d3fccc6e45bbae3b7919965f6fca0f4405853a9223f4ffd64d2daaace0c2R74-L63): Updated `DependentBuild_GeneratesWorkflow` to conditionally check the existence of the `.github/workflows` directory and read the workflow file based on the operating system.