### PR TITLE
Test features and fixes, deps updates

### DIFF
--- a/DecSm.Atom.Module.Dotnet/IDotnetTestHelper.cs
+++ b/DecSm.Atom.Module.Dotnet/IDotnetTestHelper.cs
@@ -3,7 +3,7 @@
 [TargetDefinition]
 public partial interface IDotnetTestHelper : IDotnetToolHelper
 {
-    async Task RunDotnetUnitTests(DotnetTestOptions options)
+    async Task<int> RunDotnetUnitTests(DotnetTestOptions options)
     {
         Logger.LogInformation("Running unit tests for Atom project {AtomProjectName}", options.ProjectName);
 
@@ -58,7 +58,7 @@ public partial interface IDotnetTestHelper : IDotnetToolHelper
         FileSystem.Directory.CreateDirectory(coverageResultsPublishDirectory);
 
         // Run test
-        await GetService<ProcessRunner>()
+        var result = await GetService<ProcessRunner>()
             .RunAsync(new("dotnet",
             [
                 $"test {project.FullName}",
@@ -96,6 +96,8 @@ public partial interface IDotnetTestHelper : IDotnetToolHelper
         GenerateCoverageReport(options.ProjectName, coverageResultsPublishDirectory / "Summary.json");
 
         Logger.LogInformation("Ran unit tests for Atom project {AtomProjectName}", options.ProjectName);
+
+        return result.ExitCode;
     }
 
     private void GenerateTestReport(string projectName, string trxFile)

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
     <PackageReference Include="Shouldly" Version="4.2.1"/>
     <PackageReference Include="Spectre.Console.Testing" Version="0.49.1"/>
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.1.3"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.1.7" />
     <PackageReference Include="Verify.NUnit" Version="28.4.0"/>
   </ItemGroup>
 

--- a/DecSm.Atom.SourceGenerators.Tests/DecSm.Atom.SourceGenerators.Tests.csproj
+++ b/DecSm.Atom.SourceGenerators.Tests/DecSm.Atom.SourceGenerators.Tests.csproj
@@ -14,7 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces"
-                      Version="4.12.0" />
+                      Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/DecSm.Atom.SourceGenerators/DecSm.Atom.SourceGenerators.csproj
+++ b/DecSm.Atom.SourceGenerators/DecSm.Atom.SourceGenerators.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DecSm.Atom.SourceGenerators/DecSm.Atom.SourceGenerators.csproj
+++ b/DecSm.Atom.SourceGenerators/DecSm.Atom.SourceGenerators.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DecSm.Atom.TestUtils/DecSm.Atom.TestUtils.csproj
+++ b/DecSm.Atom.TestUtils/DecSm.Atom.TestUtils.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console.Testing" Version="0.49.1"/>
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.1.3"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DecSm.Atom.Tests/BuildTests/FileSystem/FileSystemTests.cs
+++ b/DecSm.Atom.Tests/BuildTests/FileSystem/FileSystemTests.cs
@@ -158,7 +158,7 @@ public sealed class FileSystemTests
         atomRootDirectory
             .ToString()
             .ShouldBe(Environment.OSVersion.Platform is PlatformID.Win32NT
-                ? @"C:\temp"
+                ? @"C:\temp\"
                 : "/temp");
     }
 

--- a/DecSm.Atom.Tests/BuildTests/FileSystem/FileSystemTests.cs
+++ b/DecSm.Atom.Tests/BuildTests/FileSystem/FileSystemTests.cs
@@ -159,7 +159,7 @@ public sealed class FileSystemTests
             .ToString()
             .ShouldBe(Environment.OSVersion.Platform is PlatformID.Win32NT
                 ? @"C:\temp\"
-                : "/temp");
+                : "/temp/");
     }
 
     [Test]

--- a/DecSm.Atom.Tests/DecSm.Atom.Tests.csproj
+++ b/DecSm.Atom.Tests/DecSm.Atom.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
     <PackageReference Include="Shouldly" Version="4.2.1"/>
     <PackageReference Include="Spectre.Console.Testing" Version="0.49.1"/>
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.1.3"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.1.7" />
     <PackageReference Include="Verify.NUnit" Version="28.4.0"/>
   </ItemGroup>
 

--- a/DecSm.Atom/DecSm.Atom.csproj
+++ b/DecSm.Atom/DecSm.Atom.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="21.1.3" />
+    <PackageReference Include="System.IO.Abstractions" Version="21.1.7" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Analyzers" Version="2022.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/_atom/Targets/Test/ITestAtom.cs
+++ b/_atom/Targets/Test/ITestAtom.cs
@@ -15,8 +15,13 @@ internal partial interface ITestAtom : IDotnetTestHelper
             .ProducesArtifact(AtomGithubWorkflowsTestsProjectName)
             .Executes(async () =>
             {
-                await RunDotnetUnitTests(new(AtomTestsProjectName));
-                await RunDotnetUnitTests(new(AtomSourceGeneratorTestsProjectName));
-                await RunDotnetUnitTests(new(AtomGithubWorkflowsTestsProjectName));
+                var exitCode = 0;
+
+                exitCode += await RunDotnetUnitTests(new(AtomTestsProjectName));
+                exitCode += await RunDotnetUnitTests(new(AtomSourceGeneratorTestsProjectName));
+                exitCode += await RunDotnetUnitTests(new(AtomGithubWorkflowsTestsProjectName));
+
+                if (exitCode != 0)
+                    throw new StepFailedException("One or more unit tests failed");
             });
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of unit tests and update package dependencies. The most important changes include modifying the `RunDotnetUnitTests` method to return an exit code, updating various package dependencies across multiple projects, and improving error handling in the `ITestAtom` interface.

### Improvements to unit test handling:

* [`DecSm.Atom.Module.Dotnet/IDotnetTestHelper.cs`](diffhunk://#diff-c94bf7288fde0d74c1d9a56eca55a59f0f6c59d3c019c9cb9b8f762d1fee642aL6-R6): Changed the `RunDotnetUnitTests` method to return an `int` representing the exit code, and updated the method to capture and return the exit code from the `ProcessRunner` service. [[1]](diffhunk://#diff-c94bf7288fde0d74c1d9a56eca55a59f0f6c59d3c019c9cb9b8f762d1fee642aL6-R6) [[2]](diffhunk://#diff-c94bf7288fde0d74c1d9a56eca55a59f0f6c59d3c019c9cb9b8f762d1fee642aL61-R61) [[3]](diffhunk://#diff-c94bf7288fde0d74c1d9a56eca55a59f0f6c59d3c019c9cb9b8f762d1fee642aR99-R100)

* [`_atom/Targets/Test/ITestAtom.cs`](diffhunk://#diff-f59d5f2249a49834309c23df909dc3c2b6b0cbe15041b4c6d7325875836f3db7L18-R25): Modified the `Executes` method to accumulate exit codes from multiple test runs and throw a `StepFailedException` if any tests fail.

### Package dependency updates:

* [`DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj`](diffhunk://#diff-d0e6bc456ec94a0e31f0668b90a86e4f4ce6a44f715061fd27826b7de2147994L21-R21): Updated the `TestableIO.System.IO.Abstractions.TestingHelpers` package from version `21.1.3` to `21.1.7`.

* [`DecSm.Atom.SourceGenerators/DecSm.Atom.SourceGenerators.csproj`](diffhunk://#diff-1ee2af9cea623015569f978750af8c3003ef22d2058f03a0931b1df7cb96336eL16-R16): Updated the `Microsoft.CodeAnalysis.CSharp` package from version `4.11.0` to `4.12.0`.

* `DecSm.Atom.TestUtils/DecSm.Atom.TestUtils.csproj`, `DecSm.Atom.Tests/DecSm.Atom.Tests.csproj`, `DecSm.Atom/DecSm.Atom.csproj`: Updated the `TestableIO.System.IO.Abstractions.TestingHelpers` package from version `21.1.3` to `21.1.7`. [[1]](diffhunk://#diff-e335b6328d0cd5e30c7fa1797655705e1b7ec42eedc78afd44e1488248318096L9-R9) [[2]](diffhunk://#diff-39c40427b1569647db52095e2415d0c623d98d19a8dd1ad0194a0f43d0ad12efL21-R21) [[3]](diffhunk://#diff-48675c894b051b0d997dedd2ec0991d1130b24eb17934dd6684b4953ddefee61L20-R20)

### Minor change:

* [`DecSm.Atom.Tests/BuildTests/FileSystem/FileSystemTests.cs`](diffhunk://#diff-81c5d53cc02ac7a2c7b19ca94349d612174f0e07f0cd2440aef43209e2362c74L161-R161): Fixed a path string to include a trailing backslash for Windows platform.