### PR TITLE
feat(cli): add interactive mode support for user input during builds

### DIFF
--- a/.devops/workflows/Test_BuildPrivateNugetFeed.yml
+++ b/.devops/workflows/Test_BuildPrivateNugetFeed.yml
@@ -27,7 +27,7 @@ jobs:
       - checkout: self
         fetchDepth: 0
       
-      - script: dotnet tool install --global DecSm.Atom.Tool --prerelease
+      - script: dotnet tool update --global DecSm.Atom.Tool --prerelease
         displayName: 'Install atom tool'
       
       - script: |

--- a/.devops/workflows/Test_ValidatePrivateNugetFeed.yml
+++ b/.devops/workflows/Test_ValidatePrivateNugetFeed.yml
@@ -43,7 +43,7 @@ jobs:
       - checkout: self
         fetchDepth: 0
       
-      - script: dotnet tool install --global DecSm.Atom.Tool --prerelease
+      - script: dotnet tool update --global DecSm.Atom.Tool --prerelease
         displayName: 'Install atom tool'
       
       - script: |

--- a/.github/workflows/Test_BuildPrivateNugetFeed.yml
+++ b/.github/workflows/Test_BuildPrivateNugetFeed.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install atom tool
-        run: dotnet tool install --global DecSm.Atom.Tool --prerelease
+        run: dotnet tool update --global DecSm.Atom.Tool --prerelease
         shell: bash
       
       - name: Setup NuGet

--- a/.github/workflows/Test_ValidatePrivateNugetFeed.yml
+++ b/.github/workflows/Test_ValidatePrivateNugetFeed.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install atom tool
-        run: dotnet tool install --global DecSm.Atom.Tool --prerelease
+        run: dotnet tool update --global DecSm.Atom.Tool --prerelease
         shell: bash
       
       - name: Setup NuGet

--- a/DecSm.Atom.Module.AzureKeyVault/DecSm.Atom.Module.AzureKeyVault.csproj
+++ b/DecSm.Atom.Module.AzureKeyVault/DecSm.Atom.Module.AzureKeyVault.csproj
@@ -10,11 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.Module.AzureStorage/DecSm.Atom.Module.AzureStorage.csproj
+++ b/DecSm.Atom.Module.AzureStorage/DecSm.Atom.Module.AzureStorage.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.Module.DevopsWorkflows/DecSm.Atom.Module.DevopsWorkflows.csproj
+++ b/DecSm.Atom.Module.DevopsWorkflows/DecSm.Atom.Module.DevopsWorkflows.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.Module.DevopsWorkflows/Generation/DevopsWorkflowWriter.cs
+++ b/DecSm.Atom.Module.DevopsWorkflows/Generation/DevopsWorkflowWriter.cs
@@ -361,7 +361,7 @@ internal sealed partial class DevopsWorkflowWriter(
                         .ToList();
 
                     // TODO: Remove preview flag once v1.0.0 is released
-                    using (WriteSection("- script: dotnet tool install --global DecSm.Atom.Tool --prerelease"))
+                    using (WriteSection("- script: dotnet tool update --global DecSm.Atom.Tool --prerelease"))
                         WriteLine("displayName: 'Install atom tool'");
 
                     WriteLine();

--- a/DecSm.Atom.Module.Dotnet/DecSm.Atom.Module.Dotnet.csproj
+++ b/DecSm.Atom.Module.Dotnet/DecSm.Atom.Module.Dotnet.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.Module.Dotnet/DotnetToolService.cs
+++ b/DecSm.Atom.Module.Dotnet/DotnetToolService.cs
@@ -47,7 +47,7 @@ public partial interface IDotnetToolHelper
             : string.Empty;
 
         GetService<ProcessRunner>()
-            .Run(new("dotnet", $"tool install {toolName} {versionFlag} {globalFlag}")
+            .Run(new("dotnet", $"tool update {toolName} {versionFlag} {globalFlag}")
             {
                 InvocationLogLevel = LogLevel.Debug,
             });
@@ -97,7 +97,7 @@ public partial interface IDotnetToolHelper
             : string.Empty;
 
         await GetService<ProcessRunner>()
-            .RunAsync(new("dotnet", $"tool install {toolName} {versionFlag} {globalFlag}")
+            .RunAsync(new("dotnet", $"tool update {toolName} {versionFlag} {globalFlag}")
             {
                 InvocationLogLevel = LogLevel.Debug,
             });

--- a/DecSm.Atom.Module.GitVersion/DecSm.Atom.Module.GitVersion.csproj
+++ b/DecSm.Atom.Module.GitVersion/DecSm.Atom.Module.GitVersion.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
@@ -7,19 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-    <PackageReference Include="NUnit" Version="4.2.2"/>
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
     <PackageReference Include="Shouldly" Version="4.2.1"/>
     <PackageReference Include="Spectre.Console.Testing" Version="0.49.1"/>
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.1.7" />
-    <PackageReference Include="Verify.NUnit" Version="28.4.0"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.2.1" />
+    <PackageReference Include="Verify.NUnit" Version="28.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,19 +27,19 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.Module.GithubWorkflows/DecSm.Atom.Module.GithubWorkflows.csproj
+++ b/DecSm.Atom.Module.GithubWorkflows/DecSm.Atom.Module.GithubWorkflows.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
@@ -283,7 +283,7 @@ internal sealed class GithubWorkflowWriter(
                     // TODO: Remove preview flag once v1.0.0 is released
                     using (WriteSection("- name: Install atom tool"))
                     {
-                        WriteLine("run: dotnet tool install --global DecSm.Atom.Tool --prerelease");
+                        WriteLine("run: dotnet tool update --global DecSm.Atom.Tool --prerelease");
                         WriteLine("shell: bash");
                     }
 

--- a/DecSm.Atom.SourceGenerators.Tests/DecSm.Atom.SourceGenerators.Tests.csproj
+++ b/DecSm.Atom.SourceGenerators.Tests/DecSm.Atom.SourceGenerators.Tests.csproj
@@ -7,43 +7,42 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9"/>
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces"
-                      Version="4.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="Verify.NUnit" Version="28.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+    <PackageReference Include="NUnit" Version="4.3.2"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
+    <PackageReference Include="Shouldly" Version="4.2.1"/>
+    <PackageReference Include="Verify.NUnit" Version="28.7.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DecSm.Atom\DecSm.Atom.csproj" />
-    <ProjectReference Include="..\DecSm.Atom.SourceGenerators\DecSm.Atom.SourceGenerators.csproj" />
+    <ProjectReference Include="..\DecSm.Atom\DecSm.Atom.csproj"/>
+    <ProjectReference Include="..\DecSm.Atom.SourceGenerators\DecSm.Atom.SourceGenerators.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/DecSm.Atom.SourceGenerators/DecSm.Atom.SourceGenerators.csproj
+++ b/DecSm.Atom.SourceGenerators/DecSm.Atom.SourceGenerators.csproj
@@ -13,16 +13,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.TestUtils/DecSm.Atom.TestUtils.csproj
+++ b/DecSm.Atom.TestUtils/DecSm.Atom.TestUtils.csproj
@@ -6,20 +6,20 @@
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console.Testing" Version="0.49.1"/>
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.1.7" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.2.1" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0"/>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.Tests/ClassTests/Params/ParamServiceTests.cs
+++ b/DecSm.Atom.Tests/ClassTests/Params/ParamServiceTests.cs
@@ -10,13 +10,14 @@ public class ParamServiceTests
         _buildDefinition = A.Fake<IBuildDefinition>();
         _args = new(true, Array.Empty<CommandArg>());
         _config = A.Fake<IConfiguration>();
+        _console = A.Fake<IAnsiConsole>();
 
         _vaultProviders = new List<ISecretsProvider>
         {
             A.Fake<ISecretsProvider>(),
         };
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
     }
 
     [TearDown]
@@ -26,6 +27,7 @@ public class ParamServiceTests
     private IBuildDefinition _buildDefinition;
     private CommandLineArgs _args;
     private IConfiguration _config;
+    private IAnsiConsole _console;
     private IEnumerable<ISecretsProvider> _vaultProviders;
     private ParamService _paramService;
 
@@ -51,7 +53,7 @@ public class ParamServiceTests
             })
             .Build();
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -87,7 +89,7 @@ public class ParamServiceTests
             })
             .Build();
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -123,7 +125,7 @@ public class ParamServiceTests
             })
             .Build();
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -156,7 +158,7 @@ public class ParamServiceTests
 
         var vaultProvider = A.Fake<ISecretsProvider>();
         _config = new ConfigurationBuilder().Build();
-        _paramService = new(_buildDefinition, _args, _config, [vaultProvider]);
+        _paramService = new(_buildDefinition, _args, _console, _config, [vaultProvider]);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -191,7 +193,7 @@ public class ParamServiceTests
 
         var vaultProvider = A.Fake<ISecretsProvider>();
         _config = new ConfigurationBuilder().Build();
-        _paramService = new(_buildDefinition, _args, _config, [vaultProvider]);
+        _paramService = new(_buildDefinition, _args, _console, _config, [vaultProvider]);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -225,7 +227,7 @@ public class ParamServiceTests
         };
 
         _config = new ConfigurationBuilder().Build();
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -261,8 +263,9 @@ public class ParamServiceTests
             Sources = ParamSource.All,
             IsSecret = false,
         };
+
         _config = new ConfigurationBuilder().Build();
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -301,7 +304,7 @@ public class ParamServiceTests
 
         _config = new ConfigurationBuilder().Build();
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -356,7 +359,7 @@ public class ParamServiceTests
 
         _vaultProviders = [new TestSecretsProvider()];
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -397,7 +400,7 @@ public class ParamServiceTests
 
         _vaultProviders = [new TestSecretsProvider()];
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -438,7 +441,7 @@ public class ParamServiceTests
 
         _vaultProviders = [new TestSecretsProvider()];
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -479,7 +482,7 @@ public class ParamServiceTests
 
         _vaultProviders = [new TestSecretsProvider()];
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -520,7 +523,7 @@ public class ParamServiceTests
 
         _vaultProviders = [new TestSecretsProvider()];
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)
@@ -561,7 +564,7 @@ public class ParamServiceTests
 
         _vaultProviders = [new TestSecretsProvider()];
 
-        _paramService = new(_buildDefinition, _args, _config, _vaultProviders);
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
 
         A
             .CallTo(() => _buildDefinition.ParamDefinitions)

--- a/DecSm.Atom.Tests/DecSm.Atom.Tests.csproj
+++ b/DecSm.Atom.Tests/DecSm.Atom.Tests.csproj
@@ -7,19 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-    <PackageReference Include="NUnit" Version="4.2.2"/>
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
     <PackageReference Include="Shouldly" Version="4.2.1"/>
     <PackageReference Include="Spectre.Console.Testing" Version="0.49.1"/>
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.1.7" />
-    <PackageReference Include="Verify.NUnit" Version="28.4.0"/>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.2.1" />
+    <PackageReference Include="Verify.NUnit" Version="28.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,19 +27,19 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.Tool/DecSm.Atom.Tool.csproj
+++ b/DecSm.Atom.Tool/DecSm.Atom.Tool.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom/Args/CommandLineArgs.cs
+++ b/DecSm.Atom/Args/CommandLineArgs.cs
@@ -51,6 +51,12 @@ public sealed record CommandLineArgs(bool Valid, IReadOnlyList<IArg> Args)
     public bool HasProject => Args.Any(arg => arg is ProjectArg);
 
     /// <summary>
+    ///     Whether the -i / --interactive argument was provided.
+    ///     <see cref="InteractiveArg" />
+    /// </summary>
+    public bool HasInteractive => Args.Any(arg => arg is InteractiveArg);
+
+    /// <summary>
     ///     The list of parameter arguments provided.
     ///     <see cref="ParamArg" />
     /// </summary>

--- a/DecSm.Atom/Args/CommandLineArgsParser.cs
+++ b/DecSm.Atom/Args/CommandLineArgsParser.cs
@@ -116,6 +116,7 @@ internal sealed class CommandLineArgsParser(IBuildDefinition buildDefinition, IA
             "-hl" or "--headless" => new HeadlessArg(),
             "-v" or "--verbose" => new VerboseArg(),
             "-p" or "--project" => new ProjectArg(string.Empty),
+            "-i" or "--interactive" => new InteractiveArg(),
             _ => null,
         };
 

--- a/DecSm.Atom/Args/IArg.cs
+++ b/DecSm.Atom/Args/IArg.cs
@@ -64,3 +64,10 @@ public sealed record VerboseArg : IArg;
 /// <param name="ProjectName">The name of the project.</param>
 [PublicAPI]
 public sealed record ProjectArg(string ProjectName) : IArg;
+
+/// <summary>
+///     Instructs the build to run in interactive mode.
+///     Typically used to allow user input during the build.
+/// </summary>
+[PublicAPI]
+public sealed record InteractiveArg : IArg;

--- a/DecSm.Atom/DecSm.Atom.csproj
+++ b/DecSm.Atom/DecSm.Atom.csproj
@@ -8,16 +8,16 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="21.1.7" />
+    <PackageReference Include="System.IO.Abstractions" Version="21.2.1" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Analyzers" Version="2022.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DecSm.Atom/Params/ParamService.cs
+++ b/DecSm.Atom/Params/ParamService.cs
@@ -202,9 +202,11 @@ internal sealed class ParamService(
         if (result is not { Length: > 0 })
             return (false, default);
 
-        // Force cache as it is a user input
-        _cache[paramDefinition] = result;
+        var convertedResult = TypeUtil.Convert(result, converter);
 
-        return (true, TypeUtil.Convert(result, converter));
+        // Force cache as it is a user input
+        _cache[paramDefinition] = convertedResult;
+
+        return (true, convertedResult);
     }
 }

--- a/DecSm.Atom/Params/ParamService.cs
+++ b/DecSm.Atom/Params/ParamService.cs
@@ -21,6 +21,7 @@ public interface IParamService
 internal sealed class ParamService(
     IBuildDefinition buildDefinition,
     CommandLineArgs args,
+    IAnsiConsole console,
     IConfiguration config,
     IEnumerable<ISecretsProvider> vaultProviders
 ) : IParamService
@@ -96,6 +97,9 @@ internal sealed class ParamService(
                  paramDefinition.IsSecret &&
                  TryGetParamFromVault(paramDefinition, converter) is (true, { } vaultValue))
             result = vaultValue;
+        else if (args is { HasHeadless: false, HasInteractive: true, HasHelp: false } &&
+                 TryGetParamFromUser(paramDefinition, converter) is (true, { } userValue))
+            result = userValue;
         else
             result = defaultValue;
 
@@ -139,7 +143,6 @@ internal sealed class ParamService(
 
         if (string.IsNullOrEmpty(envVar))
             envVar = Environment.GetEnvironmentVariable(paramDefinition
-
                 .ArgName
                 .ToUpperInvariant()
                 .Replace('-', '_'));
@@ -184,5 +187,24 @@ internal sealed class ParamService(
         }
 
         return (false, default);
+    }
+
+    private (bool HasValue, T? Value) TryGetParamFromUser<T>(ParamDefinition paramDefinition, Func<string?, T?>? converter)
+    {
+        var result = console.Prompt(new TextPrompt<string>($"Enter value for parameter '{paramDefinition.ArgName}': ")
+        {
+            IsSecret = paramDefinition.IsSecret,
+            Mask = '*',
+            ShowDefaultValue = paramDefinition.DefaultValue is { Length: > 0 },
+            AllowEmpty = paramDefinition.DefaultValue is { Length: > 0 },
+        });
+
+        if (result is not { Length: > 0 })
+            return (false, default);
+
+        // Force cache as it is a user input
+        _cache[paramDefinition] = result;
+
+        return (true, TypeUtil.Convert(result, converter));
     }
 }

--- a/DecSm.Atom/Paths/AtomFileSystem.cs
+++ b/DecSm.Atom/Paths/AtomFileSystem.cs
@@ -33,6 +33,8 @@ public interface IAtomFileSystem : IFileSystem
 
     IPath IFileSystem.Path => FileSystem.Path;
 
+    IFileVersionInfoFactory IFileSystem.FileVersionInfo => FileSystem.FileVersionInfo;
+
     RootedPath GetPath(string key);
 
     RootedPath CreateRootedPath(string path) =>

--- a/DecSm.Atom/Reports/ConsoleOutcomeReporter.cs
+++ b/DecSm.Atom/Reports/ConsoleOutcomeReporter.cs
@@ -129,7 +129,8 @@ public partial class ConsoleOutcomeReporter(CommandLineArgs args, IAnsiConsole c
 
         foreach (var log in reportData)
         {
-            var messageLines = log.Message.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+            var splitPattern = new[] { '\r', '\n' };
+            var messageLines = log.Message.Split(splitPattern, StringSplitOptions.RemoveEmptyEntries);
 
             var rows = new List<IRenderable>
             {

--- a/_atom/_atom.csproj
+++ b/_atom/_atom.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Introduced `InteractiveArg` for enabling interactive mode in the CLI. Added `HasInteractive` property in `CommandLineArgs` to detect the `-i/--interactive` argument. Extended `ParamService` to prompt users for parameter inputs when in interactive mode. Adjusted `BuildExecutor` to handle execution flow for interactive and non-interactive modes. Unit tests updated to include support for `IAnsiConsole`.