### PR TITLE
Fixed issues with GetParam and non-nullable types, updated deps

### DIFF
--- a/DecSm.Atom.Module.AzureKeyVault/DecSm.Atom.Module.AzureKeyVault.csproj
+++ b/DecSm.Atom.Module.AzureKeyVault/DecSm.Atom.Module.AzureKeyVault.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DecSm.Atom.Module.AzureStorage/DecSm.Atom.Module.AzureStorage.csproj
+++ b/DecSm.Atom.Module.AzureStorage/DecSm.Atom.Module.AzureStorage.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="MimeTypes" Version="2.5.2">
       <PrivateAssets>all</PrivateAssets>

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
@@ -12,14 +12,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
     <PackageReference Include="Shouldly" Version="4.2.1"/>
     <PackageReference Include="Spectre.Console.Testing" Version="0.49.1"/>
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.2.1" />
-    <PackageReference Include="Verify.NUnit" Version="28.7.0" />
+    <PackageReference Include="Verify.NUnit" Version="28.9.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.SourceGenerators.Tests/DecSm.Atom.SourceGenerators.Tests.csproj
+++ b/DecSm.Atom.SourceGenerators.Tests/DecSm.Atom.SourceGenerators.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9"/>
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -18,11 +18,11 @@
     <PackageReference Include="NUnit" Version="4.3.2"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
     <PackageReference Include="Shouldly" Version="4.2.1"/>
-    <PackageReference Include="Verify.NUnit" Version="28.7.0" />
+    <PackageReference Include="Verify.NUnit" Version="28.9.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.TestUtils/DecSm.Atom.TestUtils.csproj
+++ b/DecSm.Atom.TestUtils/DecSm.Atom.TestUtils.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DecSm.Atom.Tests/ClassTests/Params/ParamServiceTests.cs
+++ b/DecSm.Atom.Tests/ClassTests/Params/ParamServiceTests.cs
@@ -580,6 +580,63 @@ public class ParamServiceTests
         result.ShouldBe("VaultValue");
     }
 
+    [TestCase(false)]
+    [TestCase(true)]
+    public void GetParam_BoolType_WithDefault_NoMatch_ReturnsDefault(bool defaultValue)
+    {
+        var paramDefinition = new ParamDefinition("TestParam")
+        {
+            ArgName = "test-param",
+            Description = "Test parameter",
+            DefaultValue = null,
+            Sources = ParamSource.All,
+            IsSecret = false,
+        };
+
+        _config = new ConfigurationBuilder().Build();
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        var result = _paramService.GetParam("TestParam", defaultValue);
+
+        result.ShouldBe(defaultValue);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    [TestCase(null)]
+    public void GetParam_NullableBool_WithDefault_NoMatch_ReturnsDefault(bool? defaultValue)
+    {
+        var paramDefinition = new ParamDefinition("TestParam")
+        {
+            ArgName = "test-param",
+            Description = "Test parameter",
+            DefaultValue = null,
+            Sources = ParamSource.All,
+            IsSecret = false,
+        };
+
+        _config = new ConfigurationBuilder().Build();
+        _paramService = new(_buildDefinition, _args, _console, _config, _vaultProviders);
+
+        A
+            .CallTo(() => _buildDefinition.ParamDefinitions)
+            .Returns(new Dictionary<string, ParamDefinition>
+            {
+                { "TestParam", paramDefinition },
+            });
+
+        var result = _paramService.GetParam("TestParam", defaultValue);
+
+        result.ShouldBe(defaultValue);
+    }
+
     private class TestSecretsProvider : ISecretsProvider
     {
         public string GetSecret(string secretName) =>

--- a/DecSm.Atom.Tests/DecSm.Atom.Tests.csproj
+++ b/DecSm.Atom.Tests/DecSm.Atom.Tests.csproj
@@ -12,14 +12,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
     <PackageReference Include="Shouldly" Version="4.2.1"/>
     <PackageReference Include="Spectre.Console.Testing" Version="0.49.1"/>
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.2.1" />
-    <PackageReference Include="Verify.NUnit" Version="28.7.0" />
+    <PackageReference Include="Verify.NUnit" Version="28.9.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.5.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom/DecSm.Atom.csproj
+++ b/DecSm.Atom/DecSm.Atom.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DecSm.Atom/Params/ParamService.cs
+++ b/DecSm.Atom/Params/ParamService.cs
@@ -157,17 +157,15 @@ internal sealed class ParamService(
 
     private (bool HasValue, T? Value) TryGetParamFromConfig<T>(ParamDefinition paramDefinition, Func<string?, T?>? converter)
     {
-        var configValue = config
-                              .GetSection("Params")
-                              .GetSection(paramDefinition.ArgName)
-                              .Get<T>() ??
-                          TypeUtil.Convert(config
-                                  .GetSection("Params")[paramDefinition.ArgName],
-                              converter);
+        var configSection = config
+            .GetSection("Params")
+            .GetSection(paramDefinition.ArgName);
 
-        return configValue is null
-            ? (false, default)
-            : (true, configValue);
+        var configValue = configSection.Exists()
+            ? configSection.Get<T?>() ?? TypeUtil.Convert(configSection.Value, converter)
+            : default;
+
+        return (configSection.Exists(), configValue);
     }
 
     private (bool HasValue, T? Value) TryGetParamFromVault<T>(ParamDefinition paramDefinition, Func<string?, T?>? converter)


### PR DESCRIPTION
This pull request includes several updates to package versions across multiple project files and adds new test cases to the `ParamServiceTests` class. The primary focus is on ensuring the projects use the latest versions of their dependencies and improving test coverage.

### Package Updates:

* Updated `Azure.Identity` to version `1.13.2` in `DecSm.Atom.Module.AzureKeyVault.csproj` and `DecSm.Atom.Module.AzureStorage.csproj`. [[1]](diffhunk://#diff-cd38f1709d79b1c2af6b728af435f8c40136f86777e38dea9d065a57200e861eL9-R9) [[2]](diffhunk://#diff-b8325f60a10ad0509e7dffe9bd6c2fe172331474db20454f430045bc3413c777L8-R8)
* Updated various package versions in `DecSm.Atom.Module.GithubWorkflows.Tests.csproj` and `DecSm.Atom.SourceGenerators.Tests.csproj`, including `Microsoft.Extensions.Configuration.UserSecrets`, `Verify.NUnit`, and `NUnit.Analyzers`. [[1]](diffhunk://#diff-d0e6bc456ec94a0e31f0668b90a86e4f4ce6a44f715061fd27826b7de2147994L15-R30) [[2]](diffhunk://#diff-40d7b75ff68aa279762df02d55b0632324ea29321a984653cf897eb6e2909bb2L10-R10) [[3]](diffhunk://#diff-40d7b75ff68aa279762df02d55b0632324ea29321a984653cf897eb6e2909bb2L21-R25)
* Updated `Microsoft.Extensions.Logging.Abstractions` to version `9.0.1` in `DecSm.Atom.TestUtils.csproj`.
* Updated `Microsoft.Extensions.DependencyInjection.Abstractions` and `Microsoft.Extensions.Hosting` to version `9.0.1` in `DecSm.Atom.csproj`.

### Test Enhancements:

* Added new test cases in `ParamServiceTests` to cover scenarios where `GetParam` returns default values for boolean and nullable boolean types when no match is found.

### Code Improvements:

* Refactored the `TryGetParamFromConfig` method in `ParamService.cs` to improve readability and efficiency by checking if the configuration section exists before attempting to get its value.