### PR TITLE
improvement(workflows): improve support for manual input gh workflows

### DIFF
--- a/.github/workflows/Test_ManualParams.yml
+++ b/.github/workflows/Test_ManualParams.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       test-string-param:
         description: Test string parameter
-        required: True
+        required: true
         type: string
 
 jobs:

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/ArtifactBuild.cs
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/ArtifactBuild.cs
@@ -1,6 +1,4 @@
-﻿using DecSm.Atom.Workflows.Definition.Triggers;
-
-namespace DecSm.Atom.Module.GithubWorkflows.Tests.Workflows;
+﻿namespace DecSm.Atom.Module.GithubWorkflows.Tests.Workflows;
 
 [BuildDefinition]
 public partial class ArtifactBuild : BuildDefinition,

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/DependentBuild.cs
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/DependentBuild.cs
@@ -1,6 +1,4 @@
-﻿using DecSm.Atom.Workflows.Definition.Triggers;
-
-namespace DecSm.Atom.Module.GithubWorkflows.Tests.Workflows;
+﻿namespace DecSm.Atom.Module.GithubWorkflows.Tests.Workflows;
 
 [BuildDefinition]
 public partial class DependentBuild : BuildDefinition, IGithubWorkflows, IDependentTarget1, IDependentTarget2

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/ManualInputBuild.cs
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/ManualInputBuild.cs
@@ -1,0 +1,55 @@
+﻿namespace DecSm.Atom.Module.GithubWorkflows.Tests.Workflows;
+
+[BuildDefinition]
+public partial class ManualInputBuild : BuildDefinition, IGithubWorkflows, IManualInputTarget
+{
+    public override IReadOnlyList<WorkflowDefinition> Workflows =>
+    [
+        new("manual-input-workflow")
+        {
+            Triggers =
+            [
+                new ManualTrigger
+                {
+                    Inputs =
+                    [
+                        ManualStringInput.ForParam(ParamDefinitions[Params.StringParamWithoutDefault]),
+                        ManualStringInput.ForParam(ParamDefinitions[Params.StringParamWithDefault]),
+                        ManualBoolInput.ForParam(ParamDefinitions[Params.BoolParamWithoutDefault]),
+                        ManualBoolInput.ForParam(ParamDefinitions[Params.BoolParamWithDefault]),
+                        ManualChoiceInput.ForParam(ParamDefinitions[Params.ChoiceParamWithoutDefault],
+                            ["choice 1", "choice 2", "choice 3"]),
+                        ManualChoiceInput.ForParam(ParamDefinitions[Params.ChoiceParamWithDefault],
+                            ["choice 1", "choice 2", "choice 3"]),
+                    ],
+                },
+            ],
+            StepDefinitions = [Commands.ManualInputTarget],
+            WorkflowTypes = [Github.WorkflowType],
+        },
+    ];
+}
+
+[TargetDefinition]
+public partial interface IManualInputTarget
+{
+    [ParamDefinition("string-param-without-default", "String param")]
+    string StringParamWithoutDefault => GetParam(() => StringParamWithoutDefault)!;
+
+    [ParamDefinition("string-param-with-default", "String param", "default-value")]
+    string StringParamWithDefault => GetParam(() => StringParamWithDefault)!;
+
+    [ParamDefinition("bool-param-without-default", "Bool param")]
+    bool BoolParamWithoutDefault => GetParam(() => BoolParamWithoutDefault)!;
+
+    [ParamDefinition("bool-param-with-default", "Bool param", "true")]
+    bool BoolParamWithDefault => GetParam(() => BoolParamWithDefault)!;
+
+    [ParamDefinition("choice-param-without-default", "Choice param")]
+    string ChoiceParamWithoutDefault => GetParam(() => ChoiceParamWithoutDefault)!;
+
+    [ParamDefinition("choice-param-with-default", "Choice param", "choice 1")]
+    string ChoiceParamWithDefault => GetParam(() => ChoiceParamWithDefault)!;
+
+    Target ManualInputTarget => d => d;
+}

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/SimpleBuild.cs
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/SimpleBuild.cs
@@ -1,6 +1,4 @@
-﻿using DecSm.Atom.Workflows.Definition.Triggers;
-
-namespace DecSm.Atom.Module.GithubWorkflows.Tests.Workflows;
+﻿namespace DecSm.Atom.Module.GithubWorkflows.Tests.Workflows;
 
 [BuildDefinition]
 public partial class SimpleBuild : BuildDefinition, IGithubWorkflows, ISimpleTarget

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.ManualInputBuild_GeneratesWorkflow.verified.txt
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.ManualInputBuild_GeneratesWorkflow.verified.txt
@@ -1,0 +1,55 @@
+﻿name: manual-input-workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      string-param-without-default:
+        description: String param
+        required: true
+        type: string
+      string-param-with-default:
+        description: String param
+        required: false
+        type: string
+        default: default-value
+      bool-param-without-default:
+        description: Bool param
+        required: true
+        type: boolean
+      bool-param-with-default:
+        description: Bool param
+        required: false
+        type: boolean
+        default: true
+      choice-param-without-default:
+        description: Choice param
+        required: true
+        type: choice
+        options:
+          - choice 1
+          - choice 2
+          - choice 3
+      choice-param-with-default:
+        description: Choice param
+        required: false
+        type: choice
+        options:
+          - choice 1
+          - choice 2
+          - choice 3
+        default: choice 1
+
+jobs:
+  
+  ManualInputTarget:
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: ManualInputTarget
+        id: ManualInputTarget
+        run: dotnet run --project AtomTest/AtomTest.csproj ManualInputTarget --skip --headless

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs
@@ -123,4 +123,27 @@ public class WorkflowTests
         await Verify(workflow);
         await TestContext.Out.WriteAsync(workflow);
     }
+
+    [Test]
+    public async Task ManualInputBuild_GeneratesWorkflow()
+    {
+        // Arrange
+        var fileSystem = FileSystemUtils.DefaultMockFileSystem;
+        var build = CreateTestHost<ManualInputBuild>(fileSystem: fileSystem, commandLineArgs: new(true, [new GenArg()]));
+
+        // Act
+        await build.RunAsync();
+
+        // Assert
+        fileSystem
+            .DirectoryInfo
+            .New(WorkflowDir)
+            .Exists
+            .ShouldBeTrue();
+
+        var workflow = await fileSystem.File.ReadAllTextAsync($"{WorkflowDir}manual-input-workflow.yml");
+
+        await Verify(workflow);
+        await TestContext.Out.WriteAsync(workflow);
+    }
 }

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/_usings.cs
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/_usings.cs
@@ -6,6 +6,7 @@ global using DecSm.Atom.Params;
 global using DecSm.Atom.TestUtils;
 global using DecSm.Atom.Workflows.Definition;
 global using DecSm.Atom.Workflows.Definition.Command;
+global using DecSm.Atom.Workflows.Definition.Triggers;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
 global using Shouldly;

--- a/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
@@ -37,16 +37,16 @@ internal sealed class GithubWorkflowWriter(
                                 using (WriteSection($"{input.Name}:"))
                                 {
                                     WriteLine($"description: {input.Description}");
-                                    WriteLine($"required: {input.Required}");
+                                    WriteLine($"required: {input.Required.ToString().ToLower()}");
 
                                     switch (input)
                                     {
                                         case ManualBoolInput boolInput:
 
-                                            WriteLine("type: bool");
+                                            WriteLine("type: boolean");
 
                                             if (boolInput.DefaultValue is not null)
-                                                WriteLine($"default: {boolInput.DefaultValue}");
+                                                WriteLine($"default: {boolInput.DefaultValue.ToString()?.ToLower()}");
 
                                             break;
 
@@ -61,7 +61,7 @@ internal sealed class GithubWorkflowWriter(
 
                                         case ManualChoiceInput choiceInput:
 
-                                            WriteLine("type: string");
+                                            WriteLine("type: choice");
 
                                             using (WriteSection("options:"))
                                             {


### PR DESCRIPTION
This pull request includes several changes to improve the handling of GitHub workflows and input parameters in the `DecSm.Atom.Module.GithubWorkflows` project. The most important changes include adding a new workflow class for manual input, updating the workflow writer to correctly format input parameters, and removing unnecessary using directives.

### Improvements to GitHub Workflows:

* Added a new workflow class `ManualInputBuild` that defines a manual input workflow with various parameter types and their definitions. (`DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/ManualInputBuild.cs`)
* Updated the workflow writer to correctly format input parameters, ensuring boolean and choice types are handled properly. (`DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs`) [[1]](diffhunk://#diff-41d2cc2bb98244492454ddac16c93e39be0d094441ab14a9ac5564d185ed2745L40-R49) [[2]](diffhunk://#diff-41d2cc2bb98244492454ddac16c93e39be0d094441ab14a9ac5564d185ed2745L64-R64)

### Code Cleanup:

* Removed unnecessary `using` directives from multiple workflow test files. (`DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/ArtifactBuild.cs`, `DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/DependentBuild.cs`, `DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/SimpleBuild.cs`) [[1]](diffhunk://#diff-9a19f587f192bf239af76c590dbefea0320f69d62f49b51b04cadfeaf3ec1912L1-R1) [[2]](diffhunk://#diff-ab85b756382b0c908f0530a7b779c7effa477556d520cecb6f541e50fa9e7e74L1-R1) [[3]](diffhunk://#diff-0d6c76eb4c2d3d772737c35729ee6be75d7afb8ddff12d3eb29045ae6fa67280L1-R1)
* Added a missing `using` directive for `Triggers` in the global usings file. (`DecSm.Atom.Module.GithubWorkflows.Tests/_usings.cs`)

### Test Enhancements:

* Added a new test method `ManualInputBuild_GeneratesWorkflow` to verify the correct generation of the manual input workflow. (`DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs`)

### Minor Fixes:

* Corrected the case for the `required` field in the `Test_ManualParams.yml` GitHub workflow file. (`.github/workflows/Test_ManualParams.yml`)
* Added a verified output file for the manual input workflow test. (`DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.ManualInputBuild_GeneratesWorkflow.verified.txt`)