### PR TITLE
feat(github-workflows): add support for creating dotnet setup step

### DIFF
--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/SetupDotnetBuild.cs
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/SetupDotnetBuild.cs
@@ -1,0 +1,21 @@
+﻿namespace DecSm.Atom.Module.GithubWorkflows.Tests.Workflows;
+
+[BuildDefinition]
+public partial class SetupDotnetBuild : BuildDefinition, IGithubWorkflows, ISetupDotnetTarget
+{
+    public override IReadOnlyList<WorkflowDefinition> Workflows =>
+    [
+        new("setup-dotnet")
+        {
+            Triggers = [GitPushTrigger.ToMain],
+            StepDefinitions = [Commands.SetupDotnetTarget.WithAddedOptions(new SetupDotnetStep("9.0.x"))],
+            WorkflowTypes = [Github.WorkflowType],
+        },
+    ];
+}
+
+[TargetDefinition]
+public partial interface ISetupDotnetTarget
+{
+    Target SetupDotnetTarget => d => d;
+}

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.SetupDotnetBuild_GeneratesWorkflow.verified.txt
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.SetupDotnetBuild_GeneratesWorkflow.verified.txt
@@ -1,0 +1,24 @@
+﻿name: setup-dotnet
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  
+  SetupDotnetTarget:
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      
+      - name: SetupDotnetTarget
+        id: SetupDotnetTarget
+        run: dotnet run --project AtomTest/AtomTest.csproj SetupDotnetTarget --skip --headless

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/Workflows/WorkflowTests.cs
@@ -146,4 +146,27 @@ public class WorkflowTests
         await Verify(workflow);
         await TestContext.Out.WriteAsync(workflow);
     }
+
+    [Test]
+    public async Task SetupDotnetBuild_GeneratesWorkflow()
+    {
+        // Arrange
+        var fileSystem = FileSystemUtils.DefaultMockFileSystem;
+        var build = CreateTestHost<SetupDotnetBuild>(fileSystem: fileSystem, commandLineArgs: new(true, [new GenArg()]));
+
+        // Act
+        await build.RunAsync();
+
+        // Assert
+        fileSystem
+            .DirectoryInfo
+            .New(WorkflowDir)
+            .Exists
+            .ShouldBeTrue();
+
+        var workflow = await fileSystem.File.ReadAllTextAsync($"{WorkflowDir}setup-dotnet.yml");
+
+        await Verify(workflow);
+        await TestContext.Out.WriteAsync(workflow);
+    }
 }

--- a/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/Generation/GithubWorkflowWriter.cs
@@ -267,6 +267,21 @@ internal sealed class GithubWorkflowWriter(
                         .Append(buildSlice)
                         .ToArray();
 
+                var setupDotnetSteps = workflow
+                    .Options
+                    .Concat(commandStep.Options)
+                    .OfType<SetupDotnetStep>()
+                    .ToList();
+
+                if (setupDotnetSteps.Count > 0)
+                    foreach (var setupDotnetStep in setupDotnetSteps)
+                        using (WriteSection("- uses: actions/setup-dotnet@v4"))
+                        {
+                            if (setupDotnetStep.DotnetVersion is { Length: > 0 })
+                                using (WriteSection("with:"))
+                                    WriteLine($"dotnet-version: '{setupDotnetSteps[0].DotnetVersion}'");
+                        }
+
                 var setupNugetSteps = workflow
                     .Options
                     .Concat(commandStep.Options)

--- a/DecSm.Atom.Module.GithubWorkflows/SetupDotnetStep.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/SetupDotnetStep.cs
@@ -1,0 +1,4 @@
+﻿namespace DecSm.Atom.Module.GithubWorkflows;
+
+[PublicAPI]
+public sealed record SetupDotnetStep(string? DotnetVersion = null) : CustomStep;


### PR DESCRIPTION
This commit introduces the `SetupDotnetBuild` definition to generate GitHub Actions workflows for .NET projects with version configuration.

- Added `SetupDotnetStep` record for handling .NET version setup.
- Extended `GithubWorkflowWriter` to support `actions/setup-dotnet`.
- Included unit tests to verify workflow generation.
- Added a test workflow file with configuration for .NET 9.0.x.

These changes streamline the creation of .NET-specific workflows.