### PR TITLE
fix(versioning): handle missing preReleaseTag in GitVersion parsing

### DIFF
--- a/DecSm.Atom.Module.GitVersion/GitVersionBuildVersionProvider.cs
+++ b/DecSm.Atom.Module.GitVersion/GitVersionBuildVersionProvider.cs
@@ -37,7 +37,9 @@ internal sealed class GitVersionBuildVersionProvider(IDotnetToolHelper dotnetToo
                 .GetProperty("PreReleaseTag")
                 .GetString()!;
 
-            return _version = SemVer.Parse($"{majorProp}.{minorProp}.{patchProp}-{preReleaseTagProp}");
+            return _version = preReleaseTagProp is { Length: > 0 }
+                ? SemVer.Parse($"{majorProp}.{minorProp}.{patchProp}-{preReleaseTagProp}")
+                : SemVer.Parse($"{majorProp}.{minorProp}.{patchProp}");
         }
     }
 }


### PR DESCRIPTION
Previously, the code would always append preReleaseTag, even if empty, resulting in invalid semantic version strings. Updated logic to only append preReleaseTag if it has a non-zero length, ensuring valid version output.

 -----

This pull request includes a change to the `GitVersionBuildVersionProvider.cs` file to improve the handling of semantic versioning when the pre-release tag is empty.

Changes in semantic versioning handling:

* [`DecSm.Atom.Module.GitVersion/GitVersionBuildVersionProvider.cs`](diffhunk://#diff-0e6acf4d6b537b883ae818dc9a0fcdd0863c4d850a7c750675f5b049e35360c7L40-R42): Modified the `Version` method to check if the `preReleaseTagProp` is non-empty before including it in the semantic version string. If `preReleaseTagProp` is empty, it now returns the version without the pre-release tag.