### PR TITLE
feat(github-workflows): add GitHub release asset upload functionality

### DIFF
--- a/.github/workflows/Test_ReleaseArtifact_Upload.yml
+++ b/.github/workflows/Test_ReleaseArtifact_Upload.yml
@@ -1,0 +1,51 @@
+name: Test_ReleaseArtifact_Upload
+
+on:
+  workflow_dispatch:
+
+jobs:
+  
+  PackAtom:
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: PackAtom
+        id: PackAtom
+        run: dotnet run --project _atom/_atom.csproj PackAtom --skip --headless
+      
+      - name: Upload DecSm.Atom
+        uses: actions/upload-artifact@v4
+        with:
+          name: DecSm.Atom
+          path: "${{ github.workspace }}/.github/publish/DecSm.Atom"
+  
+  TestGithubReleaseAssetUpload:
+    needs: [ PackAtom ]
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Download DecSm.Atom
+        uses: actions/download-artifact@v4
+        with:
+          name: DecSm.Atom
+          path: "${{ github.workspace }}/.github/artifacts/DecSm.Atom"
+      
+      - name: TestGithubReleaseAssetUpload
+        id: TestGithubReleaseAssetUpload
+        run: dotnet run --project _atom/_atom.csproj TestGithubReleaseAssetUpload --skip --headless
+        env:
+          azure-vault-app-secret: ${{ secrets.AZURE_VAULT_APP_SECRET }}
+          azure-vault-address: ${{ vars.AZURE_VAULT_ADDRESS }}
+          azure-vault-tenant-id: ${{ vars.AZURE_VAULT_TENANT_ID }}
+          azure-vault-app-id: ${{ vars.AZURE_VAULT_APP_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/DecSm.Atom.Module.GithubWorkflows/DecSm.Atom.Module.GithubWorkflows.csproj
+++ b/DecSm.Atom.Module.GithubWorkflows/DecSm.Atom.Module.GithubWorkflows.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DecSm.Atom.Module.GithubWorkflows/Extensions.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/Extensions.cs
@@ -7,4 +7,7 @@ public static class Extensions
         commandDefinition
             .WithAddedMatrixDimensions(new MatrixDimension(nameof(IJobRunsOn.JobRunsOn), labels))
             .WithAddedOptions(GithubRunsOn.SetByMatrix);
+
+    public static CommandDefinition WithGithubTokenInjection(this CommandDefinition commandDefinition) =>
+        commandDefinition.WithAddedOptions(WorkflowSecretInjection.Create(nameof(IGithubHelper.GithubToken)));
 }

--- a/DecSm.Atom.Module.GithubWorkflows/IGithubHelper.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/IGithubHelper.cs
@@ -1,0 +1,8 @@
+namespace DecSm.Atom.Module.GithubWorkflows;
+
+[TargetDefinition]
+public partial interface IGithubHelper
+{
+    [SecretDefinition("github-token", "Github Token")]
+    string GithubToken => GetParam(() => GithubToken)!;
+}

--- a/DecSm.Atom.Module.GithubWorkflows/IGithubReleaseHelper.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/IGithubReleaseHelper.cs
@@ -1,0 +1,38 @@
+﻿namespace DecSm.Atom.Module.GithubWorkflows;
+
+[TargetDefinition]
+public partial interface IGithubReleaseHelper : IGithubHelper
+{
+    async Task UploadAssetToRelease(string releaseTag, RootedPath assetPath)
+    {
+        var client = new GitHubClient(new("DecSm.Atom"), new InMemoryCredentialStore(new(GithubToken)));
+
+        var releases = await client.Repository.Release.GetAll(long.Parse(Github.Variables.RepositoryId));
+
+        var release = releases.FirstOrDefault(x => x.TagName == releaseTag);
+
+        if (assetPath.DirectoryExists)
+        {
+            var zipPath = FileSystem.CreateRootedPath($"{assetPath}.zip");
+            ZipFile.CreateFromDirectory(assetPath, zipPath);
+            assetPath = zipPath;
+        }
+
+        var assetFile = FileSystem.FileInfo.New(assetPath);
+
+        if (assetFile.FullName.EndsWith(".zip"))
+        {
+            // zip the file
+            var zipPath = FileSystem.CreateRootedPath($"{assetPath}.zip");
+            ZipFile.CreateFromDirectory(assetPath.Parent!, zipPath);
+            assetPath = zipPath;
+        }
+
+        assetFile = FileSystem.FileInfo.New(assetPath);
+
+        await using var stream = assetFile.OpenRead();
+
+        var asset = new ReleaseAssetUpload(assetFile.Name, "application/zip", stream, TimeSpan.FromMinutes(5));
+        await client.Repository.Release.UploadAsset(release, asset);
+    }
+}

--- a/DecSm.Atom.Module.GithubWorkflows/_usings.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/_usings.cs
@@ -1,3 +1,4 @@
+global using System.IO.Compression;
 global using System.Reflection;
 global using System.Text;
 global using DecSm.Atom.Artifacts;
@@ -22,3 +23,5 @@ global using JetBrains.Annotations;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.DependencyInjection.Extensions;
 global using Microsoft.Extensions.Logging;
+global using Octokit;
+global using Octokit.Internal;

--- a/_atom/Build.cs
+++ b/_atom/Build.cs
@@ -26,7 +26,8 @@ internal partial class Build : DefaultBuildDefinition,
     ITestPrivateNugetRestore,
     IPublishTester,
     ITestManualParams,
-    ITestSecretProvider
+    ITestSecretProvider,
+    ITestGithubReleaseAssetUpload
 {
     private static AddNugetFeedsStep AddNugetFeedsStep =>
         new()
@@ -98,6 +99,12 @@ internal partial class Build : DefaultBuildDefinition,
         },
 
         // Test workflows
+        new("Test_ReleaseArtifact_Upload")
+        {
+            Triggers = [ManualTrigger.Empty],
+            StepDefinitions = [Commands.TestGithubReleaseAssetUpload.WithGithubTokenInjection()],
+            WorkflowTypes = [Github.WorkflowType],
+        },
         new("Test_ManualParams")
         {
             Triggers =

--- a/_atom/Targets/TestGithubReleaseAssetUpload.cs
+++ b/_atom/Targets/TestGithubReleaseAssetUpload.cs
@@ -1,0 +1,11 @@
+﻿namespace Atom.Targets;
+
+[TargetDefinition]
+internal partial interface ITestGithubReleaseAssetUpload : IGithubReleaseHelper, IPackAtom
+{
+    Target TestGithubReleaseAssetUpload =>
+        d => d
+            .RequiresParam(Params.GithubToken)
+            .ConsumesArtifact(Commands.PackAtom, AtomProjectName)
+            .Executes(async () => await UploadAssetToRelease("test1", FileSystem.AtomArtifactsDirectory / AtomProjectName));
+}


### PR DESCRIPTION
Introduced `IGithubHelper` and `IGithubReleaseHelper` interfaces for managing GitHub tokens and uploading release assets. Added a sample workflow `Test_ReleaseArtifact_Upload` for testing the feature. Integrated Octokit library to handle GitHub API interactions. Extended system to zip and upload artifacts to a specific release.