### PR TITLE
fix(github-assets): Fixed zip logic

### DIFF
--- a/DecSm.Atom.Module.GithubWorkflows/IGithubReleaseHelper.cs
+++ b/DecSm.Atom.Module.GithubWorkflows/IGithubReleaseHelper.cs
@@ -20,7 +20,7 @@ public partial interface IGithubReleaseHelper : IGithubHelper
 
         var assetFile = FileSystem.FileInfo.New(assetPath);
 
-        if (assetFile.FullName.EndsWith(".zip"))
+        if (!assetFile.FullName.EndsWith(".zip"))
         {
             // zip the file
             var zipPath = FileSystem.CreateRootedPath($"{assetPath}.zip");
@@ -32,7 +32,7 @@ public partial interface IGithubReleaseHelper : IGithubHelper
 
         await using var stream = assetFile.OpenRead();
 
-        var asset = new ReleaseAssetUpload(assetFile.Name, "application/zip", stream, TimeSpan.FromMinutes(5));
+        var asset = new ReleaseAssetUpload(assetPath.FileName, "application/zip", stream, TimeSpan.FromMinutes(5));
         await client.Repository.Release.UploadAsset(release, asset);
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `UploadAssetToRelease` method in the `DecSm.Atom.Module.GithubWorkflows/IGithubReleaseHelper.cs` file to fix a bug and improve the handling of asset uploads. The most important changes are:

Bug fix:
* Corrected the condition to check if the asset file does not end with ".zip" before attempting to zip it.

Improvement to asset uploads:
* Modified the `ReleaseAssetUpload` instantiation to use `assetPath.FileName` instead of `assetFile.Name` for better accuracy in naming the uploaded asset.