### PR TITLE
fix(azure-storage): extend retry policy for BlobServiceClient

### DIFF
--- a/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
+++ b/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
@@ -27,7 +27,17 @@ public sealed class AzureBlobArtifactProvider(
         var connectionString = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageConnectionString));
         var container = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageContainer));
         var buildName = paramService.GetParam(nameof(IBuildInfo.AtomBuildName));
-        var containerClient = new BlobContainerClient(connectionString, container);
+
+        var serviceClient = new BlobServiceClient(connectionString,
+            new()
+            {
+                Retry =
+                {
+                    NetworkTimeout = TimeSpan.FromMinutes(3),
+                },
+            });
+
+        var containerClient = serviceClient.GetBlobContainerClient(container);
 
         var invalidPathChars = fileSystem.Path.GetInvalidPathChars();
         var pathSafeRegex = new Regex($"[{Regex.Escape(new(invalidPathChars))}]");
@@ -87,7 +97,18 @@ public sealed class AzureBlobArtifactProvider(
         var connectionString = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageConnectionString));
         var container = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageContainer));
         var buildName = paramService.GetParam(nameof(IBuildInfo.AtomBuildName));
-        var containerClient = new BlobContainerClient(connectionString, container);
+
+
+        var serviceClient = new BlobServiceClient(connectionString,
+            new()
+            {
+                Retry =
+                {
+                    NetworkTimeout = TimeSpan.FromMinutes(3),
+                },
+            });
+
+        var containerClient = serviceClient.GetBlobContainerClient(container);
 
         var invalidPathChars = fileSystem.Path.GetInvalidPathChars();
         var pathSafeRegex = new Regex($"[{Regex.Escape(new(invalidPathChars))}]");


### PR DESCRIPTION
Updated AzureBlobArtifactProvider to use BlobServiceClient with a custom retry policy, setting a network timeout of 3 minutes.

Might be worth allowing this to be customizable in the future.

-----

This pull request includes changes to the `DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs` file to improve the handling of Azure Blob Storage clients. The most important changes involve the introduction of a `BlobServiceClient` with custom retry policies for network timeouts.

Improvements to Azure Blob Storage client handling:

* [`DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs`](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L30-R40): Replaced direct instantiation of `BlobContainerClient` with a `BlobServiceClient` that includes a custom retry policy setting a network timeout of 3 minutes. [[1]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L30-R40) [[2]](diffhunk://#diff-d0f56726426a47b8688d1ee6f134262bf8a5d0f309ebb3999e30037a6dae6293L90-R111)