### PR TITLE
fix(dotnet-pack): include configuration option in pack command

### DIFF
--- a/DecSm.Atom.Module.Dotnet/IDotnetPackHelper.cs
+++ b/DecSm.Atom.Module.Dotnet/IDotnetPackHelper.cs
@@ -42,7 +42,7 @@ public partial interface IDotnetPackHelper : IVersionHelper
             FileSystem.Directory.Delete(packDirectory, true);
 
         await GetService<ProcessRunner>()
-            .RunAsync(new("dotnet", $"pack {project.FullName}"));
+            .RunAsync(new("dotnet", $"pack {project.FullName} -c {options.Configuration}"));
 
         var packageName = FileSystem
             .Directory


### PR DESCRIPTION
Previously, the `dotnet pack` command did not include the configuration option, potentially leading to incorrect builds.

-----

This pull request includes a change to the `DotnetPackProject` method in the `DecSm.Atom.Module.Dotnet/IDotnetPackHelper.cs` file. The change enhances the functionality by allowing the configuration to be specified when running the `dotnet pack` command.

* [`DecSm.Atom.Module.Dotnet/IDotnetPackHelper.cs`](diffhunk://#diff-08c512551566debfdda390b0b2e865593abb6014ae903d62c8c12b7d0f2a56d7L45-R45): Modified the `RunAsync` method call to include the configuration parameter from `DotnetPackOptions` when executing the `dotnet pack` command.