### PR TITLE
feat(dotnet-pack): add support for custom package ID during packing

### DIFF
--- a/DecSm.Atom.Module.Dotnet/DotnetPackOptions.cs
+++ b/DecSm.Atom.Module.Dotnet/DotnetPackOptions.cs
@@ -8,4 +8,6 @@ public sealed record DotnetPackOptions(string ProjectName)
     public string Configuration { get; init; } = "Release";
 
     public string? OutputArtifactName { get; init; }
+
+    public string? CustomPackageId { get; init; }
 }

--- a/DecSm.Atom.Module.Dotnet/IDotnetPackHelper.cs
+++ b/DecSm.Atom.Module.Dotnet/IDotnetPackHelper.cs
@@ -44,14 +44,18 @@ public partial interface IDotnetPackHelper : IVersionHelper
         await GetService<ProcessRunner>()
             .RunAsync(new("dotnet", $"pack {project.FullName} -c {options.Configuration}"));
 
-        var packageName = FileSystem
+        var packageFilePattern = options.CustomPackageId is { Length: > 0 }
+            ? $"{options.CustomPackageId}.*.nupkg"
+            : $"{options.ProjectName}.*.nupkg";
+
+        var packageFileName = FileSystem
             .Directory
-            .GetFiles(FileSystem.AtomRootDirectory / options.ProjectName / "bin" / options.Configuration, $"{options.ProjectName}.*.nupkg")
+            .GetFiles(FileSystem.AtomRootDirectory / options.ProjectName / "bin" / options.Configuration, packageFilePattern)
             .OrderByDescending(x => x)
             .First();
 
         // Move package to publish directory
-        var packagePath = FileSystem.AtomRootDirectory / options.ProjectName / "bin" / options.Configuration / $"{packageName}";
+        var packagePath = FileSystem.AtomRootDirectory / options.ProjectName / "bin" / options.Configuration / $"{packageFileName}";
 
         if (!packagePath.FileExists)
             throw new InvalidOperationException($"Package {packagePath} does not exist.");


### PR DESCRIPTION
This pull request introduces a new feature to allow custom package IDs in the dotnet packing process and updates the logic accordingly. The key changes include the addition of a new property in `DotnetPackOptions` and modifications to the `DotnetPackProject` method to handle the custom package ID.

### New Feature: Custom Package ID

* [`DecSm.Atom.Module.Dotnet/DotnetPackOptions.cs`](diffhunk://#diff-38b80142b04036b21c9b8bc2dd3475a306ffc2f961179be09e13c5ce926c41b4R11-R12): Added a new property `CustomPackageId` to the `DotnetPackOptions` record to allow specifying a custom package ID.

### Logic Update for Dotnet Packing

* [`DecSm.Atom.Module.Dotnet/IDotnetPackHelper.cs`](diffhunk://#diff-08c512551566debfdda390b0b2e865593abb6014ae903d62c8c12b7d0f2a56d7L47-R58): Updated the `DotnetPackProject` method to use the `CustomPackageId` if provided, otherwise default to using the `ProjectName` for the package file pattern. This change ensures that the correct package file is identified and moved to the publish directory.