### PR TITLE
chore: upgrade to .NET 9 and update project configurations

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: SetupBuildInfo
         id: SetupBuildInfo
@@ -32,6 +35,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAtom
         id: PackAtom
@@ -51,6 +57,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAtomTool
         id: PackAtomTool
@@ -70,6 +79,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAzureKeyVaultModule
         id: PackAzureKeyVaultModule
@@ -89,6 +101,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAzureStorageModule
         id: PackAzureStorageModule
@@ -108,6 +123,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackDevopsWorkflowsModule
         id: PackDevopsWorkflowsModule
@@ -127,6 +145,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackDotnetModule
         id: PackDotnetModule
@@ -146,6 +167,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackGithubWorkflowsModule
         id: PackGithubWorkflowsModule
@@ -165,6 +189,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackGitVersionModule
         id: PackGitVersionModule
@@ -184,6 +211,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackPrivateTestLib
         id: PackPrivateTestLib
@@ -206,6 +236,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: TestAtom
         id: TestAtom
@@ -241,6 +274,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: Download DecSm.Atom
         uses: actions/download-artifact@v4

--- a/.github/workflows/CleanupBuilds.yml
+++ b/.github/workflows/CleanupBuilds.yml
@@ -16,6 +16,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: CleanupPrereleaseArtifacts
         id: CleanupPrereleaseArtifacts

--- a/.github/workflows/Test_BuildPrivateNugetFeed.yml
+++ b/.github/workflows/Test_BuildPrivateNugetFeed.yml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: SetupBuildInfo
         id: SetupBuildInfo
@@ -34,6 +37,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       - name: Install atom tool
         run: dotnet tool update --global DecSm.Atom.Tool --prerelease
         shell: bash
@@ -59,6 +65,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackPrivateTestLib
         id: PackPrivateTestLib
@@ -81,6 +90,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: Download PrivateTestLib
         uses: actions/download-artifact@v4

--- a/.github/workflows/Test_BuildWithCustomArtifacts.yml
+++ b/.github/workflows/Test_BuildWithCustomArtifacts.yml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: SetupBuildInfo
         id: SetupBuildInfo
@@ -35,6 +38,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAtom
         id: PackAtom
@@ -62,6 +68,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAtomTool
         id: PackAtomTool
@@ -89,6 +98,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAzureKeyVaultModule
         id: PackAzureKeyVaultModule
@@ -116,6 +128,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAzureStorageModule
         id: PackAzureStorageModule
@@ -143,6 +158,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackDevopsWorkflowsModule
         id: PackDevopsWorkflowsModule
@@ -170,6 +188,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackDotnetModule
         id: PackDotnetModule
@@ -197,6 +218,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackGithubWorkflowsModule
         id: PackGithubWorkflowsModule
@@ -224,6 +248,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackGitVersionModule
         id: PackGitVersionModule
@@ -254,6 +281,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: TestAtom
         id: TestAtom
@@ -284,6 +314,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: RetrieveArtifact
         run: dotnet run --project _atom/_atom.csproj RetrieveArtifact --skip --headless

--- a/.github/workflows/Test_ManualParams.yml
+++ b/.github/workflows/Test_ManualParams.yml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: TestManualParams
         id: TestManualParams

--- a/.github/workflows/Test_ValidatePrivateNugetFeed.yml
+++ b/.github/workflows/Test_ValidatePrivateNugetFeed.yml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: SetupBuildInfo
         id: SetupBuildInfo
@@ -32,6 +35,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackPrivateTestLib
         id: PackPrivateTestLib
@@ -51,6 +57,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       - name: Install atom tool
         run: dotnet tool update --global DecSm.Atom.Tool --prerelease
         shell: bash

--- a/.github/workflows/Validate.yml
+++ b/.github/workflows/Validate.yml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: SetupBuildInfo
         id: SetupBuildInfo
@@ -32,6 +35,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAtom
         id: PackAtom
@@ -45,6 +51,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAtomTool
         id: PackAtomTool
@@ -58,6 +67,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAzureKeyVaultModule
         id: PackAzureKeyVaultModule
@@ -71,6 +83,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackAzureStorageModule
         id: PackAzureStorageModule
@@ -84,6 +99,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackDevopsWorkflowsModule
         id: PackDevopsWorkflowsModule
@@ -97,6 +115,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackDotnetModule
         id: PackDotnetModule
@@ -110,6 +131,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackGithubWorkflowsModule
         id: PackGithubWorkflowsModule
@@ -123,6 +147,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PackGitVersionModule
         id: PackGitVersionModule
@@ -136,6 +163,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: PublishTester
         id: PublishTester
@@ -152,6 +182,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       
       - name: TestAtom
         id: TestAtom

--- a/DecSm.Atom.Module.AzureKeyVault/DecSm.Atom.Module.AzureKeyVault.csproj
+++ b/DecSm.Atom.Module.AzureKeyVault/DecSm.Atom.Module.AzureKeyVault.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DecSm.Atom.Module.AzureStorage/DecSm.Atom.Module.AzureStorage.csproj
+++ b/DecSm.Atom.Module.AzureStorage/DecSm.Atom.Module.AzureStorage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DecSm.Atom.Module.DevopsWorkflows/DecSm.Atom.Module.DevopsWorkflows.csproj
+++ b/DecSm.Atom.Module.DevopsWorkflows/DecSm.Atom.Module.DevopsWorkflows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DecSm.Atom.Module.Dotnet/DecSm.Atom.Module.Dotnet.csproj
+++ b/DecSm.Atom.Module.Dotnet/DecSm.Atom.Module.Dotnet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DecSm.Atom.Module.GitVersion/DecSm.Atom.Module.GitVersion.csproj
+++ b/DecSm.Atom.Module.GitVersion/DecSm.Atom.Module.GitVersion.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
+++ b/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <UserSecretsId>decsm.atom.tests</UserSecretsId>
   </PropertyGroup>

--- a/DecSm.Atom.Module.GithubWorkflows/DecSm.Atom.Module.GithubWorkflows.csproj
+++ b/DecSm.Atom.Module.GithubWorkflows/DecSm.Atom.Module.GithubWorkflows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DecSm.Atom.SourceGenerators.Tests/DecSm.Atom.SourceGenerators.Tests.csproj
+++ b/DecSm.Atom.SourceGenerators.Tests/DecSm.Atom.SourceGenerators.Tests.csproj
@@ -1,28 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.6.0"/>
+    <PackageReference Include="Basic.Reference.Assemblies.Net90" Version="1.8.0"/>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
     <PackageReference Include="NUnit" Version="4.3.2"/>
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0"/>
     <PackageReference Include="Shouldly" Version="4.3.0"/>
-    <PackageReference Include="Verify.NUnit" Version="28.15.0"/>
+    <PackageReference Include="Verify.NUnit" Version="29.3.1"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DecSm.Atom.SourceGenerators.Tests/Utils/TestUtils.cs
+++ b/DecSm.Atom.SourceGenerators.Tests/Utils/TestUtils.cs
@@ -27,7 +27,7 @@ public static class TestUtils
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(source);
 
-        var references = Net80.References.All.Concat(additionalAssemblies.Select(a => MetadataReference.CreateFromFile(a.Location)));
+        var references = Net90.References.All.Concat(additionalAssemblies.Select(a => MetadataReference.CreateFromFile(a.Location)));
 
         var compilation = CSharpCompilation.Create("Tests", [syntaxTree], references);
 

--- a/DecSm.Atom.TestUtils/DecSm.Atom.TestUtils.csproj
+++ b/DecSm.Atom.TestUtils/DecSm.Atom.TestUtils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DecSm.Atom.Tests/DecSm.Atom.Tests.csproj
+++ b/DecSm.Atom.Tests/DecSm.Atom.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <UserSecretsId>decsm.atom.tests</UserSecretsId>
   </PropertyGroup>

--- a/DecSm.Atom.Tool/DecSm.Atom.Tool.csproj
+++ b/DecSm.Atom.Tool/DecSm.Atom.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>atom</ToolCommandName>
   </PropertyGroup>

--- a/DecSm.Atom/DecSm.Atom.csproj
+++ b/DecSm.Atom/DecSm.Atom.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,12 +9,18 @@
     <EnablePackageValidation>true</EnablePackageValidation>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;NU5104;RCS1001;RCS1003;RCS1123;</NoWarn>
-    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <DebugType>embedded</DebugType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PrivateTestLib/PrivateTestLib.csproj
+++ b/PrivateTestLib/PrivateTestLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PrivateTestLibTester/PrivateTestLibTester.csproj
+++ b/PrivateTestLibTester/PrivateTestLibTester.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PublishTester/PublishTester.csproj
+++ b/PublishTester/PublishTester.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/_atom/Build.cs
+++ b/_atom/Build.cs
@@ -43,7 +43,7 @@ internal partial class Build : DefaultBuildDefinition,
 
     public override IReadOnlyList<IWorkflowOption> DefaultWorkflowOptions =>
     [
-        UseAzureKeyVault.Enabled, UseGitVersionForBuildId.Enabled, new DevopsVariableGroup("Atom"),
+        UseAzureKeyVault.Enabled, UseGitVersionForBuildId.Enabled, new DevopsVariableGroup("Atom"), new SetupDotnetStep("9.0.x"),
     ];
 
     public override IReadOnlyList<WorkflowDefinition> Workflows =>

--- a/_atom/_atom.csproj
+++ b/_atom/_atom.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Atom</RootNamespace>
     <UserSecretsId>661f5aa6-694c-4890-85c0-9b72f0bea988</UserSecretsId>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "sdk": {
-    "version": "8.0.0",
+    "version": "9.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
- Updated all projects to target `net9.0` alongside `net8.0`, enabling multi-target framework support.
- Updated `global.json` to use .NET SDK 9.0.0.
- Adjusted test and workflow configurations to include `dotnet-version: 9.0.x`.
- Bumped language version to C# 13 and added new build settings for Release mode.
- Upgraded package references to align with new framework compatibility.

BREAKING CHANGE: Projects now require .NET SDK 9.0 or higher.