### PR TITLE
fix(source-generator): handle global namespace for class generation

### DIFF
--- a/DecSm.Atom.SourceGenerators/BuildDefinitionSourceGenerator.cs
+++ b/DecSm.Atom.SourceGenerators/BuildDefinitionSourceGenerator.cs
@@ -137,6 +137,10 @@ public class BuildDefinitionSourceGenerator : IIncrementalGenerator
         var @class = classDeclarationSyntax.Identifier.Text;
         var classFull = $"{@namespace}.{@class}";
 
+        var globalUsingStaticLine = @namespace is "<global namespace>"
+            ? string.Empty
+            : $"global using static {classFull};";
+
         var interfacesWithProperties = classSymbol
             .AllInterfaces
             .SelectMany(static interfaceSymbol => interfaceSymbol
@@ -334,7 +338,7 @@ public class BuildDefinitionSourceGenerator : IIncrementalGenerator
 
                      #nullable enable
 
-                     global using static {{classFull}};
+                     {{globalUsingStaticLine}}
                      using System.Diagnostics.CodeAnalysis;
                      using System.Linq.Expressions;
                      using Microsoft.Extensions.DependencyInjection;

--- a/DecSm.Atom.SourceGenerators/GenerateEntryPointSourceGenerator.cs
+++ b/DecSm.Atom.SourceGenerators/GenerateEntryPointSourceGenerator.cs
@@ -70,7 +70,11 @@ public class GenerateEntryPointSourceGenerator : IIncrementalGenerator
 
     private static void GeneratePartialBuild(SourceProductionContext context, INamedTypeSymbol classSymbol, string className)
     {
-        var fullClassName = $"{classSymbol.ContainingNamespace.ToDisplayString()}.{className}";
+        var containingNamespace = classSymbol.ContainingNamespace.ToDisplayString();
+
+        var fullClassName = containingNamespace is "<global namespace>" or "global"
+            ? className
+            : $"{containingNamespace}.{className}";
 
         // Build up the source code
         var code = $"""


### PR DESCRIPTION
Previously, class generation did not correctly consider the global namespace. Updated logic ensures proper handling for classes in the global or unnamed namespace.