### PR TITLE
fix(AzureBlobArtifactProvider): use IBuildInfo for build name

### DIFF
--- a/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
+++ b/DecSm.Atom.Module.AzureStorage/AzureBlobArtifactProvider.cs
@@ -1,9 +1,8 @@
-﻿using DecSm.Atom.BuildInfo;
-
-namespace DecSm.Atom.Module.AzureStorage;
+﻿namespace DecSm.Atom.Module.AzureStorage;
 
 [PublicAPI]
 public sealed class AzureBlobArtifactProvider(
+    IBuildInfo buildInfo,
     IParamService paramService,
     ReportService reportService,
     IAtomFileSystem fileSystem,
@@ -32,7 +31,7 @@ public sealed class AzureBlobArtifactProvider(
 
         var connectionString = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageConnectionString));
         var container = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageContainer));
-        var buildName = paramService.GetParam(nameof(IBuildInfo.BuildName));
+        var buildName = buildInfo.BuildName;
 
         var serviceClient = new BlobServiceClient(connectionString,
             new()
@@ -110,7 +109,7 @@ public sealed class AzureBlobArtifactProvider(
 
         var connectionString = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageConnectionString));
         var container = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageContainer));
-        var buildName = paramService.GetParam(nameof(IBuildInfo.BuildName));
+        var buildName = buildInfo.BuildName;
 
         var serviceClient = new BlobServiceClient(connectionString,
             new()
@@ -192,7 +191,7 @@ public sealed class AzureBlobArtifactProvider(
     {
         var connectionString = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageConnectionString));
         var container = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageContainer));
-        var buildName = paramService.GetParam(nameof(ISetupBuildInfo.BuildName));
+        var buildName = buildInfo.BuildName;
         var containerClient = new BlobContainerClient(connectionString, container);
 
         foreach (var buildId in runIdentifiers)
@@ -221,7 +220,7 @@ public sealed class AzureBlobArtifactProvider(
     {
         var connectionString = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageConnectionString));
         var container = paramService.GetParam(nameof(IAzureArtifactStorage.AzureArtifactStorageContainer));
-        var buildName = paramService.GetParam(nameof(ISetupBuildInfo.BuildName));
+        var buildName = buildInfo.BuildName;
         var containerClient = new BlobContainerClient(connectionString, container);
 
         if (artifactName is { Length: > 0 })

--- a/DecSm.Atom.Module.AzureStorage/_usings.cs
+++ b/DecSm.Atom.Module.AzureStorage/_usings.cs
@@ -3,6 +3,7 @@ global using Azure.Storage.Blobs;
 global using Azure.Storage.Blobs.Models;
 global using DecSm.Atom.Artifacts;
 global using DecSm.Atom.Build.Definition;
+global using DecSm.Atom.BuildInfo;
 global using DecSm.Atom.Hosting;
 global using DecSm.Atom.Params;
 global using DecSm.Atom.Paths;

--- a/DecSm.Atom/BuildInfo/IBuildInfo.cs
+++ b/DecSm.Atom/BuildInfo/IBuildInfo.cs
@@ -119,7 +119,7 @@ public interface IBuildInfo : IBuildAccessor
     [ParamDefinition("build-slice", "Unique identifier for a variation of the build, commonly used for CI/CD matrix jobs")]
     string? BuildSlice => GetParam(() => BuildSlice);
 
-    private string DefaultBuildName
+    string DefaultBuildName
     {
         get
         {
@@ -136,20 +136,20 @@ public interface IBuildInfo : IBuildAccessor
         }
     }
 
-    private string DefaultBuildId =>
+    string DefaultBuildId =>
         GetService<IBuildIdProvider>()
             .BuildId;
 
-    private SemVer DefaultBuildVersion =>
+    SemVer DefaultBuildVersion =>
         GetService<IBuildVersionProvider>()
             .Version;
 
-    private static Func<string?, SemVer?> BuildVersionConverter =>
+    static Func<string?, SemVer?> BuildVersionConverter =>
         s => s is not null
             ? SemVer.Parse(s)
             : throw new ArgumentException("Invalid SemVer");
 
-    private long DefaultBuildTimestamp =>
+    long DefaultBuildTimestamp =>
         GetService<IBuildTimestampProvider>()
             .Timestamp;
 }


### PR DESCRIPTION
Replaced direct parameter acquisition with `IBuildInfo.BuildName` in `AzureBlobArtifactProvider`.