### PR TITLE
Change version flag format for dotnet tool update

### DIFF
--- a/DecSm.Atom.Module.Dotnet/Helpers/IDotnetToolInstallHelper.cs
+++ b/DecSm.Atom.Module.Dotnet/Helpers/IDotnetToolInstallHelper.cs
@@ -156,7 +156,7 @@ public interface IDotnetToolInstallHelper : IBuildAccessor
         }
 
         var versionFlag = version != null
-            ? $"-v {version}"
+            ? $"--version {version}"
             : string.Empty;
 
         await ProcessRunner.RunAsync(new("dotnet", $"tool update {toolName} {versionFlag} {globalFlag}")


### PR DESCRIPTION
This pull request makes a small but important change to the way the version flag is passed when updating a .NET tool. The code now uses the correct `--version` flag instead of the shorthand `-v`, which improves compatibility and clarity.

* Changed the version flag in the `dotnet tool update` command from `-v` to `--version` in `IDotnetToolInstallHelper.cs` to use the correct syntax.