### PR TITLE
Fix/allow test fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,7 +406,6 @@ FodyWeavers.xsd
 !src/DecSm.Atom.Build/Artifacts
 !src/DecSm.Atom.Tests/Artifacts
 atom-publish
-.gitversioncache
 
 # DocFX
 _site/

--- a/README.md
+++ b/README.md
@@ -15,37 +15,429 @@ debug it like standard code, and automatically generate CI/CD configuration file
 * **Modular**: Pull in capabilities via NuGet packages (GitVersion, Azure KeyVault, etc.).
 * **Source Generators**: Reduces boilerplate by automatically discovering targets and parameters.
 
-## Basic Example
+## Examples
 
-1. Create a new file `Build.cs`
+### Hello World
 
-   ```csharp
-   #:package DecSm.Atom@2.*
-   
-   [BuildDefinition]
-   [GenerateEntryPoint]
-   partial class Build : BuildDefinition
-   {
-       Target SayHello => t => t
-           .Executes(() => Logger.LogInformation("Hello, World!"));
-   }
+> [!NOTE]
+>
+> It is recommended to use the atom dotnet tool to invoke atom projects:
+>
+> `dotnet tool install -g DecSm.Atom.Tool`
+>
+> ` atom ...`
+>
+> However, the dotnet cli can also be used directly:
+>
+> `dotnet run -- ...`
+
+1. Create a .NET 10 project
+
+   ```
+   dotnet new console -n _atom
    ```
 
-2. Execute `dotnet run Build.cs SayHello`
+2. Update the `_atom.csproj` file:
 
-   ```
-   25-12-16 +10:00  DecSm.Atom.Build.BuildExecutor:
-   22:46:01.754 INF Executing build
-   
-   SayHello
-   
-   25-12-16 +10:00  SayHello | Build:
-   22:46:01.790 INF Hello, World!    
+    ```xml
+    <Project Sdk="Microsoft.NET.Sdk.Worker">
+    
+      <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <RootNamespace>Atom</RootNamespace>
+      </PropertyGroup>
+    
+      <ItemGroup>
+        <PackageReference Include="DecSm.Atom.Build" Version="3.*" />
+      </ItemGroup>
+    
+    </Project>
+    ```
 
-   Build Summary
-   
-     SayHello │ Succeeded │ <0.01s
+3. Replace the `Program.cs` file with `IBuild.cs`:
+
+    ```csharp
+    using DecSm.Atom.Build.Definition;
+    using DecSm.Atom.Build.Hosting;
+    
+    namespace Atom;
+    
+    [BuildDefinition]
+    [GenerateEntryPoint]
+    internal interface IBuild : IBuildDefinition
+    {
+        Target HelloWorld =>
+            t => t
+            .DescribedAs("Prints a hello world message to the console")
+            .Executes(() => Logger.LogInformation("Hello, World!"));
+    }
+    ```
+
+4. Execute `atom HelloWorld`
+
+    ```
+    26-06-06 +10:00  DecSm.Atom.Build.BuildExecutor:
+    01:16:47.552 INF Executing build
+    
+    HelloWorld
+    
+    Prints a hello world message to the console
+    
+    26-06-06 +10:00  HelloWorld | Atom.Build:      
+    01:16:47.616 INF Hello, World!
+    
+    
+    Build Summary
+    
+    HelloWorld │ Succeeded │ <0.01s
    ```
+
+### Adding Params
+
+1. Add a parameter to the `IBuild` interface:
+
+   > [!NOTE]
+   >
+   > `.RequiresParam(nameof(...))` is used to ensure the parameter is provided before the target is executed.
+   >
+   > `.UsesParam(nameof(...))` is used to use the parameter if it is provided, but not fail the build if it is not.
+
+    ```csharp
+    using DecSm.Atom.Build.Definition;
+    using DecSm.Atom.Build.Hosting;
+    using DecSm.Atom.Build.Params;
+    
+    namespace Atom;
+    
+    [BuildDefinition]
+    [GenerateEntryPoint]
+    internal interface IBuild : IBuildDefinition
+    {
+        [ParamDefinition("my-name", "My name")]
+        string? MyName => GetParam(() => MyName);
+    
+        Target HelloWorld =>
+            t => t
+                .DescribedAs("Prints a hello world message to the console")
+                .RequiresParam(nameof(MyName))
+                .Executes(() => Logger.LogInformation("Hello, World! I am {MyName}.", MyName));
+    }
+    ```
+
+2. Execute `atom HelloWorld --my-name Frodo
+
+    ```
+    26-06-06 +10:00  DecSm.Atom.Build.BuildExecutor:
+    01:23:25.405 INF Executing build
+
+    HelloWorld
+    
+    Prints a hello world message to the console
+    
+    26-06-06 +10:00  HelloWorld | Atom.Build:
+    01:23:25.467 INF Hello, World! I am Frodo.
+
+    
+    Build Summary
+
+      HelloWorld │ Succeeded │ <0.01s
+    ```
+
+### Adding Secrets
+
+1. Add a secret parameter to the `IBuild` interface:
+
+    ```csharp
+    using DecSm.Atom.Build.Definition;
+    using DecSm.Atom.Build.Hosting;
+    using DecSm.Atom.Build.Params;
+    
+    namespace Atom;
+    
+    [BuildDefinition]
+    [GenerateEntryPoint]
+    internal interface IBuild : IBuildDefinition
+    {
+        [ParamDefinition("my-name", "My name")]
+        string? MyName => GetParam(() => MyName);
+    
+        [SecretDefinition("my-secret", "My secret")]
+        string? MySecret => GetParam(() => MySecret);
+    
+        Target HelloWorld =>
+            t => t
+                .DescribedAs("Prints a hello world message to the console")
+                .RequiresParam(nameof(MyName))
+                .RequiresParam(nameof(MySecret))
+                .Executes(() =>
+                    Logger.LogInformation("Hello, World! I am {MyName} and my secret is {MySecret}.",
+                        MyName,
+                        MySecret));
+    }
+    ```
+
+2. Execute `atom HelloWorld --my-name Frodo --my-secret TheOneRing`
+
+   > [!NOTE]
+   > The secret is masked in the output.
+
+    ```
+    26-06-06 +10:00  DecSm.Atom.Build.BuildExecutor:
+    01:27:08.482 INF Executing build                
+                                                    
+    HelloWorld
+    
+    Prints a hello world message to the console
+    
+    26-06-06 +10:00  HelloWorld | Atom.Build:                        
+    01:27:08.544 INF Hello, World! I am Frodo and my secret is *****.
+                                                                     
+    
+    Build Summary
+                                         
+      HelloWorld │ Succeeded │ <0.01s
+    ```
+
+### Adding Target Dependencies
+
+1. Update the `IBuild` interface:
+
+    ```csharp
+    using DecSm.Atom.Build.Definition;
+    using DecSm.Atom.Build.Hosting;
+    using DecSm.Atom.Build.Params;
+    
+    namespace Atom;
+    
+    [BuildDefinition]
+    [GenerateEntryPoint]
+    internal interface IBuild : IBuildDefinition
+    {
+        [ParamDefinition("my-name", "My name")]
+        string? MyName => GetParam(() => MyName);
+    
+        [SecretDefinition("my-secret", "My secret")]
+        string? MySecret => GetParam(() => MySecret);
+    
+        Target HelloWorld =>
+            t => t
+                .DescribedAs("Prints a hello world message to the console")
+                .RequiresParam(nameof(MyName))
+                .RequiresParam(nameof(MySecret))
+                .Executes(() =>
+                    Logger.LogInformation("Hello, World! I am {MyName} and my secret is {MySecret}.", MyName, MySecret));
+    
+        Target Goodbye =>
+            t => t
+                .DescribedAs("Prints a goodbye message to the console")
+                .DependsOn(nameof(HelloWorld))
+                .Executes(() => Logger.LogInformation("Goodbye!"));
+    }
+    ```
+
+2. Execute `atom Goodbye --my-name Frodo --my-secret TheOneRing`
+
+   > [!NOTE]
+   > The `Goodbye` target depends on the `HelloWorld` target, so both will be executed in the correct order, and the
+   parameters only need to be provided once.
+
+    ```
+    26-06-06 +10:00  DecSm.Atom.Build.BuildExecutor:
+    01:30:12.175 INF Executing build                
+                                                    
+    HelloWorld
+    
+    Prints a hello world message to the console
+    
+    26-06-06 +10:00  HelloWorld | Atom.Build:                        
+    01:30:12.235 INF Hello, World! I am Frodo and my secret is *****.
+                                                                     
+    Goodbye
+    
+    Prints a goodbye message to the console
+    
+    26-06-06 +10:00  Goodbye | Atom.Build:
+    01:30:12.240 INF Goodbye!             
+                                          
+    
+    Build Summary
+                                         
+      HelloWorld │ Succeeded │ <0.01s    
+      Goodbye    │ Succeeded │ <0.01s
+    ```
+
+### Adding Workflow Generation
+
+1. Update the `_atom.csproj` file:
+
+    ```xml
+    <Project Sdk="Microsoft.NET.Sdk.Worker">
+    
+      <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <RootNamespace>Atom</RootNamespace>
+      </PropertyGroup>
+    
+      <ItemGroup>
+        <PackageReference Include="DecSm.Atom.Module.GithubWorkflows" Version="3.*" />
+      </ItemGroup>
+    
+    </Project>
+    ```
+2. Update the `IBuild` interface:
+
+    ```csharp
+    using DecSm.Atom.Build.BuildOptions;
+    using DecSm.Atom.Build.Definition;
+    using DecSm.Atom.Build.Hosting;
+    using DecSm.Atom.Build.Params;
+    using DecSm.Atom.Module.GithubWorkflows.Extensions;
+    using DecSm.Atom.Module.GithubWorkflows.Helpers;
+    using DecSm.Atom.Workflows;
+    using DecSm.Atom.Workflows.Definition;
+    using DecSm.Atom.Workflows.Definition.Triggers;
+    using DecSm.Atom.Workflows.Options;
+    using DecSm.StructuredText.Expressions;
+    
+    namespace Atom;
+    
+    [BuildDefinition]
+    [GenerateEntryPoint]
+    internal interface IBuild : IWorkflowBuildDefinition, IGithubWorkflows
+    {
+    [ParamDefinition("my-name", "My name")]
+    string? MyName => GetParam(() => MyName);
+    
+        [SecretDefinition("my-secret", "My secret")]
+        string? MySecret => GetParam(() => MySecret);
+    
+        Target HelloWorld =>
+            t => t
+                .DescribedAs("Prints a hello world message to the console")
+                .RequiresParam(nameof(MyName))
+                .RequiresParam(nameof(MySecret))
+                .Executes(() =>
+                    Logger.LogInformation("Hello, World! I am {MyName} and my secret is {MySecret}.", MyName, MySecret));
+    
+        Target Goodbye =>
+            t => t
+                .DescribedAs("Prints a goodbye message to the console")
+                .DependsOn(nameof(HelloWorld))
+                .Executes(() => Logger.LogInformation("Goodbye!"));
+    
+        IReadOnlyList<WorkflowDefinition> IWorkflowBuildDefinition.Workflows =>
+        [
+            new("Hello")
+            {
+                Triggers = [WorkflowTriggers.PushToMain],
+                Targets =
+                [
+                    new(nameof(HelloWorld))
+                    {
+                        Options =
+                        [
+                            BuildOptions.Inject.Param(nameof(MyName), TextExpressions.Github.GithubRepositoryOwner),
+                            BuildOptions.Inject.Secret(nameof(MySecret)),
+                        ],
+                    },
+                    new(nameof(Goodbye)),
+                ],
+                Types = [WorkflowTypes.Github.Action],
+            },
+        ];
+    }
+    ```
+
+3. Execute `atom gen`
+
+    ```
+    26-06-06 +10:00  DecSm.Atom.Module.GithubWorkflows.GithubActions.GithubWorkflowFileWriter:                                               
+    01:38:57.388 INF Writing new workflow file:                                  
+                     L:\Repos\DecSm\atom\.github\workflows\Hello.yml             
+                                                                                 
+    
+    26-06-06 +10:00  DecSm.Atom.Build.BuildExecutor:
+    01:38:57.472 INF Executing build                
+                                                    
+    Gen
+    
+    Generates workflow files
+    
+    
+    Build Summary
+                                     
+      Gen    │ Succeeded │ <0.01s
+    ```
+
+   `.github/workflows/Hello.yml`
+
+    ```yaml
+    name: Hello
+    
+    on:
+      push:
+        branches: [ main ]
+    
+    permissions: { }
+    
+    jobs:
+    
+      HelloWorld:
+        runs-on: ubuntu-latest
+        steps:
+    
+          - name: Checkout
+            uses: actions/checkout@v6
+            with:
+              fetch-depth: 0
+    
+          - name: HelloWorld
+            id: HelloWorld
+            run: dotnet run --project _atom/_atom.csproj -- HelloWorld --skip --headless
+            env:
+              my-secret: ${{ secrets.MY_SECRET }}
+              my-name: ${{ github.repository_owner }}
+    
+      Goodbye:
+        needs: [ HelloWorld ]
+        runs-on: ubuntu-latest
+        steps:
+    
+          - name: Checkout
+            uses: actions/checkout@v6
+            with:
+              fetch-depth: 0
+    
+          - name: Goodbye
+            id: Goodbye
+            run: dotnet run --project _atom/_atom.csproj -- Goodbye --skip --headless
+    ```
+
+### File-based Apps
+
+Atom can also be used as a file-based app:
+
+`Atom.cs`
+
+```csharp
+#:sdk Microsoft.NET.Sdk.Worker
+#:package DecSm.Atom.Build@3.*
+
+using DecSm.Atom.Build.Definition;
+using DecSm.Atom.Build.Hosting;
+
+namespace Atom;
+
+[BuildDefinition]
+[GenerateEntryPoint]
+internal interface IBuild : IBuildDefinition
+{
+    Target HelloWorld =>
+        t => t
+            .DescribedAs("Prints a hello world message to the console")
+            .Executes(() => Logger.LogInformation("Hello, World!"));
+}
+```
 
 ## Documentation
 

--- a/_atom/IBuild.cs
+++ b/_atom/IBuild.cs
@@ -103,7 +103,7 @@ internal interface IBuild : IWorkflowBuildDefinition,
                     [
                         BuildOptions.Target.SuppressArtifactPublishing,
                         BuildOptions.Inject.Secret(nameof(GithubToken)),
-                        new GithubTokenPermissionsOption(new Permissions.Exact(new()
+                        BuildOptions.Github.TokenPermissions.Set(new Permissions.Exact(new()
                         {
                             IdTokens = PermissionsLevel.Write,
                             Contents = PermissionsLevel.Write,

--- a/_atom/_usings.cs
+++ b/_atom/_usings.cs
@@ -8,7 +8,6 @@ global using DecSm.Atom.Build.FileSystem;
 global using DecSm.Atom.Build.Hosting;
 global using DecSm.Atom.Build.Params;
 global using DecSm.Atom.Build.Secrets;
-global using DecSm.Atom.Process;
 global using DecSm.Atom.Module.AzureKeyVault;
 global using DecSm.Atom.Module.Dotnet.Helpers;
 global using DecSm.Atom.Module.GithubWorkflows;

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -95,3 +95,33 @@ atom Compile Test --verbose
 
 It searches for the Atom project in the current directory tree (or the directory specified by `-p`).
 
+### Restore & Build Caching
+
+Because a consuming project's Atom build is distributed as source, the `atom` tool would normally trigger a
+`dotnet restore` and `dotnet build` on every invocation. To avoid this, the tool caches hashes of the relevant
+inputs and skips work that isn't needed:
+
+- **Restore** is skipped (`--no-restore`) when the build project file plus any `Directory.Build.props`,
+  `Directory.Build.targets`, `Directory.Packages.props`, `nuget.config` and `global.json` files (found while
+  walking up to the project root) are unchanged.
+- **Build** is skipped (`--no-build`) when, in addition to the restore inputs, every `.cs` source file under the
+  build project (excluding `bin`/`obj`) is unchanged and a previous build output exists. `--no-build` implies
+  `--no-restore`.
+
+The hashes are stored in the build project's `obj/.atom-restore.hash` and `obj/.atom-build.hash` files, so they
+are automatically invalidated by `dotnet clean` and never committed to source control.
+
+> Note: source changes in projects referenced via `<ProjectReference>` are not tracked by the build cache. If your
+> build project references other projects by source, force a full build with the opt-out below.
+
+To force a full restore and build regardless of the caches, use either:
+
+```shell
+# CLI flag
+atom Compile --no-restore-cache
+
+# Environment variable (any value other than "0"/"false" enables the opt-out)
+ATOM_NO_RESTORE_CACHE=1 atom Compile
+```
+
+

--- a/src/DecSm.Atom.Build.Analyzers/DecSm.Atom.Build.Analyzers.csproj
+++ b/src/DecSm.Atom.Build.Analyzers/DecSm.Atom.Build.Analyzers.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DecSm.Atom.Build.Analyzers/DecSm.Atom.Build.Analyzers.csproj
+++ b/src/DecSm.Atom.Build.Analyzers/DecSm.Atom.Build.Analyzers.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DecSm.Atom.Build.SourceGenerators/DecSm.Atom.Build.SourceGenerators.csproj
+++ b/src/DecSm.Atom.Build.SourceGenerators/DecSm.Atom.Build.SourceGenerators.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/DecSm.Atom.Build.SourceGenerators/DecSm.Atom.Build.SourceGenerators.csproj
+++ b/src/DecSm.Atom.Build.SourceGenerators/DecSm.Atom.Build.SourceGenerators.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/DecSm.Atom.Build/Definition/IBuildDefinition.cs
+++ b/src/DecSm.Atom.Build/Definition/IBuildDefinition.cs
@@ -11,7 +11,7 @@
 /// </remarks>
 [PublicAPI]
 [UsedImplicitly(ImplicitUseTargetFlags.WithInheritors)]
-public interface IBuildDefinition
+public interface IBuildDefinition : IBuildAccessor
 {
     /// <summary>
     ///     Gets the build options applied globally to this build definition.

--- a/src/DecSm.Atom.Module.AzureStorage/DecSm.Atom.Module.AzureStorage.csproj
+++ b/src/DecSm.Atom.Module.AzureStorage/DecSm.Atom.Module.AzureStorage.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.0" />
     <PackageReference Include="DecSm.Analyzers.PublicApiSurface" Version="0.1.0-rc.11" PrivateAssets="all" />
     <PackageReference Include="MimeTypes" Version="2.5.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/DecSm.Atom.Module.Dotnet/Helpers/IDotnetTestHelper.cs
+++ b/src/DecSm.Atom.Module.Dotnet/Helpers/IDotnetTestHelper.cs
@@ -46,6 +46,12 @@ public partial interface IDotnetTestHelper : IDotnetCliHelper, IBuildInfo, IDotn
     /// <param name="options">Optional. Configuration options for the testing and staging process.</param>
     /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
     /// <returns>A <see cref="Task{TResult}" /> that returns the exit code of the `dotnet test` command.</returns>
+    /// <exception cref="StepFailedException">
+    ///     Thrown when the `dotnet test` invocation fails before producing any test results (e.g. a build error,
+    ///     invalid arguments, or a crashed test host), as opposed to the run completing with failing tests. This is
+    ///     detected by the absence of a TRX results file on a non-zero exit code. Failing tests do not throw and
+    ///     instead surface via the returned exit code and the generated test report.
+    /// </exception>
     /// <remarks>
     ///     <para>
     ///         This method performs the following steps:
@@ -189,6 +195,18 @@ public partial interface IDotnetTestHelper : IDotnetCliHelper, IBuildInfo, IDotn
             },
             cancellationToken);
 
+        // A non-zero exit code can mean either "tests failed" or "the dotnet test invocation itself failed"
+        // (e.g. build error, missing project, crashed test host). These share exit codes and cannot be reliably
+        // distinguished by code alone. The TRX file is only produced when tests actually ran, so its absence on a
+        // failed result indicates the invocation failed before running any tests - in which case we throw rather
+        // than swallowing the failure and returning a misleading exit code.
+        var trxFile = testOutputDirectory / $"{projectName}.trx";
+
+        if (result.ExitCode is not 0 && !AtomFileSystem.File.Exists(trxFile))
+            throw new StepFailedException(
+                $"dotnet test failed for project {projectName} with exit code {result.ExitCode} before producing any test results. " +
+                "This indicates the test run could not start (e.g. a build error or invalid arguments) rather than failing tests.");
+
         // Copy html file to publish directory
         AtomFileSystem.File.Copy(testOutputDirectory / $"{projectName}.html",
             testResultsPublishDirectory / $"{projectName}.html");
@@ -196,7 +214,7 @@ public partial interface IDotnetTestHelper : IDotnetCliHelper, IBuildInfo, IDotn
         GenerateTestReport(projectName,
             testOptions.Configuration,
             testOptions.Framework,
-            testOutputDirectory / $"{projectName}.trx");
+            trxFile);
 
         if (!options.IncludeCoverage)
             return result.ExitCode;

--- a/src/DecSm.Atom.Module.Dotnet/Helpers/IDotnetTestHelper.cs
+++ b/src/DecSm.Atom.Module.Dotnet/Helpers/IDotnetTestHelper.cs
@@ -185,6 +185,7 @@ public partial interface IDotnetTestHelper : IDotnetCliHelper, IBuildInfo, IDotn
                 TransformError = s => s.Contains(", is an invalid character")
                     ? null
                     : s,
+                AllowFailedResult = true,
             },
             cancellationToken);
 
@@ -213,7 +214,7 @@ public partial interface IDotnetTestHelper : IDotnetCliHelper, IBuildInfo, IDotn
             },
             new("", "")
             {
-                AllowFailedResult = true,
+                AllowFailedResult = false,
             },
             cancellationToken);
 

--- a/src/DecSm.Atom.Module.GitVersion/Providers/GitVersionBuildIdProvider.cs
+++ b/src/DecSm.Atom.Module.GitVersion/Providers/GitVersionBuildIdProvider.cs
@@ -49,26 +49,9 @@ internal sealed class GitVersionBuildIdProvider(
                 .Output
                 .Trim();
 
-            var hashCache = atomFileSystem.AtomRootDirectory / ".gitversioncache" / currentGitHash;
-
-            JsonElement? jsonOutput = null;
-
             lock (_lock)
             {
-                if (atomFileSystem.File.Exists(hashCache))
-                    try
-                    {
-                        var cachedContent = atomFileSystem.File.ReadAllText(hashCache);
-                        jsonOutput = JsonSerializer.Deserialize(cachedContent, JsonElementContext.Default.JsonElement);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogWarning(ex,
-                            "Failed to read or parse cached GitVersion output. Will re-run GitVersion.");
-
-                        jsonOutput = null;
-                        atomFileSystem.File.Delete(hashCache);
-                    }
+                var jsonOutput = GitVersionCache.TryRead(atomFileSystem, currentGitHash, logger);
 
                 if (jsonOutput is null)
                 {
@@ -82,8 +65,7 @@ internal sealed class GitVersionBuildIdProvider(
                     jsonOutput = JsonSerializer.Deserialize(gitVersionResult.Output,
                         JsonElementContext.Default.JsonElement);
 
-                    atomFileSystem.Directory.CreateDirectory(atomFileSystem.AtomRootDirectory / ".gitversioncache");
-                    atomFileSystem.File.WriteAllText(hashCache, jsonOutput.Value.GetRawText());
+                    GitVersionCache.Write(atomFileSystem, currentGitHash, jsonOutput.Value);
                 }
 
                 var buildId = jsonOutput

--- a/src/DecSm.Atom.Module.GitVersion/Providers/GitVersionBuildVersionProvider.cs
+++ b/src/DecSm.Atom.Module.GitVersion/Providers/GitVersionBuildVersionProvider.cs
@@ -48,26 +48,9 @@ internal sealed class GitVersionBuildVersionProvider(
                 .Output
                 .Trim();
 
-            var hashCache = atomFileSystem.AtomRootDirectory / ".gitversioncache" / currentGitHash;
-
-            JsonElement? jsonOutput = null;
-
             lock (_lock)
             {
-                if (atomFileSystem.File.Exists(hashCache))
-                    try
-                    {
-                        var cachedContent = atomFileSystem.File.ReadAllText(hashCache);
-                        jsonOutput = JsonSerializer.Deserialize(cachedContent, JsonElementContext.Default.JsonElement);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogWarning(ex,
-                            "Failed to read or parse cached GitVersion output. Will re-run GitVersion.");
-
-                        jsonOutput = null;
-                        atomFileSystem.File.Delete(hashCache);
-                    }
+                var jsonOutput = GitVersionCache.TryRead(atomFileSystem, currentGitHash, logger);
 
                 if (jsonOutput is null)
                 {
@@ -81,8 +64,7 @@ internal sealed class GitVersionBuildVersionProvider(
                     jsonOutput = JsonSerializer.Deserialize(gitVersionResult.Output,
                         JsonElementContext.Default.JsonElement);
 
-                    atomFileSystem.Directory.CreateDirectory(atomFileSystem.AtomRootDirectory / ".gitversioncache");
-                    atomFileSystem.File.WriteAllText(hashCache, jsonOutput.Value.GetRawText());
+                    GitVersionCache.Write(atomFileSystem, currentGitHash, jsonOutput.Value);
                 }
 
                 var majorProp = jsonOutput

--- a/src/DecSm.Atom.Module.GitVersion/Providers/GitVersionCache.cs
+++ b/src/DecSm.Atom.Module.GitVersion/Providers/GitVersionCache.cs
@@ -1,0 +1,93 @@
+namespace DecSm.Atom.Module.GitVersion.Providers;
+
+/// <summary>
+///     Reads and writes a single-file cache of GitVersion output, keyed by the current Git commit hash.
+/// </summary>
+/// <remarks>
+///     The cache is a single file in the build project's <c>obj</c> directory (so it is git-ignored and removed
+///     by <c>dotnet clean</c>). The first line stores the Git hash the output was generated for, and the
+///     remainder stores the raw GitVersion JSON. When the current hash no longer matches, the cache is ignored
+///     and overwritten - just like the tool's restore/build caches, which each track a single hash file rather
+///     than one file per key.
+/// </remarks>
+internal static class GitVersionCache
+{
+    private const string CacheFileName = ".gitversioncache";
+
+    /// <summary>
+    ///     Returns the cached GitVersion output if it was generated for <paramref name="gitHash" />; otherwise
+    ///     <c>null</c>.
+    /// </summary>
+    internal static JsonElement? TryRead(IAtomFileSystem fileSystem, string gitHash, ILogger logger)
+    {
+        var cacheFile = GetCacheFile(fileSystem);
+
+        if (!fileSystem.File.Exists(cacheFile))
+            return null;
+
+        try
+        {
+            var content = fileSystem.File.ReadAllText(cacheFile);
+            var newlineIndex = content.IndexOf('\n');
+
+            if (newlineIndex < 0)
+                return null;
+
+            var cachedHash = content[..newlineIndex]
+                .Trim();
+
+            // The cached output belongs to a different commit - treat it as a miss.
+            if (!string.Equals(cachedHash, gitHash, StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            return JsonSerializer.Deserialize(content[(newlineIndex + 1)..], JsonElementContext.Default.JsonElement);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read or parse cached GitVersion output. Will re-run GitVersion.");
+
+            try
+            {
+                fileSystem.File.Delete(cacheFile);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup; a locked file should never break the build.
+            }
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     Persists the GitVersion output for <paramref name="gitHash" />, overwriting any previous entry.
+    /// </summary>
+    internal static void Write(IAtomFileSystem fileSystem, string gitHash, JsonElement output)
+    {
+        fileSystem.Directory.CreateDirectory(ResolveObjDirectory(fileSystem));
+        fileSystem.File.WriteAllText(GetCacheFile(fileSystem), $"{gitHash}\n{output.GetRawText()}");
+    }
+
+    private static RootedPath GetCacheFile(IAtomFileSystem fileSystem) =>
+        ResolveObjDirectory(fileSystem) / CacheFileName;
+
+    private static RootedPath ResolveObjDirectory(IAtomFileSystem fileSystem)
+    {
+        // The build runs from '<project>/bin/<config>/<tfm>/', so walk up from the running assembly's
+        // directory to find the project directory (the first ancestor that contains an 'obj' folder).
+        var current = fileSystem.CreateRootedPath(AppContext.BaseDirectory);
+
+        while (current.Parent is { } parent)
+        {
+            var objDir = parent / "obj";
+
+            if (objDir.DirectoryExists)
+                return objDir;
+
+            current = parent;
+        }
+
+        // Fallback: use an 'obj' directory under the atom root if the project's obj cannot be located.
+        return fileSystem.AtomRootDirectory / "obj";
+    }
+}

--- a/src/DecSm.Atom.Tool/BuildCache.cs
+++ b/src/DecSm.Atom.Tool/BuildCache.cs
@@ -1,0 +1,135 @@
+namespace DecSm.Atom.Tool;
+
+/// <summary>
+///     Content-hash based cache that lets <see cref="Commands.RunCommand" /> decide whether a
+///     <c>dotnet build</c> can be skipped (by passing <c>--no-build</c> to <c>dotnet run</c>).
+/// </summary>
+/// <remarks>
+///     The cache hashes the project's restore inputs plus every <c>.cs</c> source file under the project
+///     directory (excluding <c>bin</c>/<c>obj</c>), and is stored in <c>obj/.atom-build.hash</c>. A build is
+///     only skippable when a previous build output (<c>bin/&lt;project&gt;.dll</c>) exists and the cached hash
+///     matches.
+///     <para>
+///         Note: source changes in projects referenced via <c>&lt;ProjectReference&gt;</c> are not tracked.
+///         Use <c>--no-restore-cache</c> (or the <c>ATOM_NO_RESTORE_CACHE</c> environment variable) to force a
+///         full restore and build.
+///     </para>
+/// </remarks>
+internal static class BuildCache
+{
+    private const string CacheFileName = ".atom-build.hash";
+
+    private static readonly string[] ExcludedFolderNames = ["bin", "obj"];
+
+    /// <summary>
+    ///     Represents the outcome of evaluating the build cache for a given target.
+    /// </summary>
+    /// <param name="CanSkipBuild">Whether the build can be skipped because nothing relevant changed.</param>
+    /// <param name="ComputedHash">The freshly computed hash of the build-affecting inputs.</param>
+    /// <param name="CacheFilePath">The path of the cache file used to persist the hash.</param>
+    internal sealed record BuildDecision(bool CanSkipBuild, string ComputedHash, string CacheFilePath);
+
+    /// <summary>
+    ///     Computes the build input hash and compares it against the cached value to determine whether a
+    ///     build can be skipped.
+    /// </summary>
+    internal static BuildDecision Evaluate(IFileSystem fileSystem, IFileInfo target)
+    {
+        var projectDir = target.Directory?.FullName ?? fileSystem.Path.GetDirectoryName(target.FullName)!;
+        var objDir = fileSystem.Path.Combine(projectDir, "obj");
+        var cacheFilePath = fileSystem.Path.Combine(objDir, CacheFileName);
+
+        var inputs = RestoreCache.CollectRestoreInputs(fileSystem, target, projectDir);
+        var sources = CollectSourceFiles(fileSystem, projectDir);
+
+        var computedHash = HashCache.ComputeHash(fileSystem, projectDir, inputs.Concat(sources));
+
+        // A build can only be skipped if a previous build actually produced an assembly and the cached hash
+        // matches the current inputs.
+        var canSkip = HasBuildOutput(fileSystem, projectDir, target) &&
+                      fileSystem.File.Exists(cacheFilePath) &&
+                      string.Equals(HashCache.TryRead(fileSystem, cacheFilePath),
+                          computedHash,
+                          StringComparison.OrdinalIgnoreCase);
+
+        return new(canSkip, computedHash, cacheFilePath);
+    }
+
+    /// <summary>
+    ///     Persists the computed hash so a subsequent run can skip the build. Best-effort: failures are ignored.
+    /// </summary>
+    internal static void Save(IFileSystem fileSystem, BuildDecision decision) =>
+        HashCache.Write(fileSystem, decision.CacheFilePath, decision.ComputedHash);
+
+    private static bool HasBuildOutput(IFileSystem fileSystem, string projectDir, IFileInfo target)
+    {
+        var binDir = fileSystem.Path.Combine(projectDir, "bin");
+
+        if (!fileSystem.Directory.Exists(binDir))
+            return false;
+
+        var assemblyFileName = $"{fileSystem.Path.GetFileNameWithoutExtension(target.Name)}.dll";
+
+        try
+        {
+            return fileSystem
+                .Directory
+                .EnumerateFiles(binDir, assemblyFileName, SearchOption.AllDirectories)
+                .Any();
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static List<string> CollectSourceFiles(IFileSystem fileSystem, string projectDir)
+    {
+        var result = new List<string>();
+        var queue = new Queue<string>();
+        queue.Enqueue(projectDir);
+
+        while (queue.Count > 0)
+        {
+            var dir = queue.Dequeue();
+
+            try
+            {
+                result.AddRange(fileSystem.Directory.EnumerateFiles(dir, "*.cs"));
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            try
+            {
+                foreach (var sub in fileSystem.Directory.EnumerateDirectories(dir))
+                {
+                    var name = fileSystem.Path.GetFileName(sub);
+
+                    if (!ExcludedFolderNames.Contains(name, StringComparer.OrdinalIgnoreCase))
+                        queue.Enqueue(sub);
+                }
+            }
+            catch (IOException)
+            {
+                // Ignore directories we cannot enumerate.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Ignore directories we cannot access.
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/DecSm.Atom.Tool/CommandModel.cs
+++ b/src/DecSm.Atom.Tool/CommandModel.cs
@@ -29,6 +29,9 @@ internal sealed class CommandModel
     /// <param name="file">
     ///     Optional. The path to a C# file to run as a file-based DecSm.Atom application.
     /// </param>
+    /// <param name="noRestoreCache">
+    ///     Optional. When set, bypasses the restore cache and always performs a <c>dotnet restore</c>.
+    /// </param>
     /// <param name="cancellationToken">A cancellation token to observe while waiting for the command to complete.</param>
     /// <returns>The exit code of the executed DecSm.Atom build command.</returns>
     [Command("")]
@@ -38,6 +41,7 @@ internal sealed class CommandModel
         [Argument] string[]? runArgs = null,
         [HideDefaultValue] string? project = null,
         [HideDefaultValue] string? file = null,
+        bool noRestoreCache = false,
         CancellationToken cancellationToken = default) =>
         RunCommand.Handle(context
                 .Arguments
@@ -48,6 +52,7 @@ internal sealed class CommandModel
                 : file is { Length: > 0 }
                     ? file
                     : string.Empty,
+            noRestoreCache,
             cancellationToken);
 
     /// <summary>

--- a/src/DecSm.Atom.Tool/Commands/RunCommand.cs
+++ b/src/DecSm.Atom.Tool/Commands/RunCommand.cs
@@ -16,14 +16,50 @@ internal static class RunCommand
     public static bool MockDotnetCli { get; set; }
 
     /// <summary>
+    ///     Indicates whether the most recent <see cref="Execute" /> call passed <c>--no-restore</c> to
+    ///     <c>dotnet run</c> (i.e. the restore was skipped because of the restore cache). Exposed for testing.
+    /// </summary>
+    [UsedImplicitly(Reason = "Used in tests")]
+    public static bool LastUsedNoRestore { get; private set; }
+
+    /// <summary>
+    ///     Indicates whether the most recent <see cref="Execute" /> call passed <c>--no-build</c> to
+    ///     <c>dotnet run</c> (i.e. the build was skipped because of the build cache). Exposed for testing.
+    /// </summary>
+    [UsedImplicitly(Reason = "Used in tests")]
+    public static bool LastUsedNoBuild { get; private set; }
+
+    /// <summary>
     ///     Executes the specified DecSm.Atom project.
     /// </summary>
     /// <param name="runArgs">Arguments to pass directly to the DecSm.Atom project.</param>
     /// <param name="subject">The name of the DecSm.Atom project or file-based app to run (e.g., "_atom").</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>The exit code of the executed `dotnet run` command.</returns>
-    public static async Task<int> Handle(string[] runArgs, string subject, CancellationToken cancellationToken)
+    public static Task<int> Handle(string[] runArgs, string subject, CancellationToken cancellationToken) =>
+        Handle(runArgs, subject, false, cancellationToken);
+
+    /// <summary>
+    ///     Executes the specified DecSm.Atom project.
+    /// </summary>
+    /// <param name="runArgs">Arguments to pass directly to the DecSm.Atom project.</param>
+    /// <param name="subject">The name of the DecSm.Atom project or file-based app to run (e.g., "_atom").</param>
+    /// <param name="noRestoreCache">
+    ///     When <c>true</c>, the restore cache is bypassed and a normal restore is always performed.
+    /// </param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The exit code of the executed `dotnet run` command.</returns>
+    public static async Task<int> Handle(
+        string[] runArgs,
+        string subject,
+        bool noRestoreCache,
+        CancellationToken cancellationToken)
     {
+        LastUsedNoRestore = false;
+        LastUsedNoBuild = false;
+
+        var forceRestore = noRestoreCache || IsRestoreCacheDisabledByEnv();
+
         subject = subject
             .Replace("\n", string.Empty)
             .Replace("\r", string.Empty)
@@ -41,7 +77,8 @@ internal static class RunCommand
         {
             case SubjectInputType.Project:
             {
-                var knownProjectResult = await FindAndExecuteKnownProject(subject, runArgs, cancellationToken);
+                var knownProjectResult =
+                    await FindAndExecuteKnownProject(subject, runArgs, forceRestore, cancellationToken);
 
                 if (knownProjectResult is not null)
                     return knownProjectResult.Value;
@@ -53,7 +90,7 @@ internal static class RunCommand
 
             case SubjectInputType.File:
             {
-                var knownFileResult = await FindAndExecuteKnownFile(subject, runArgs, cancellationToken);
+                var knownFileResult = await FindAndExecuteKnownFile(subject, runArgs, forceRestore, cancellationToken);
 
                 if (knownFileResult is not null)
                     return knownFileResult.Value;
@@ -65,7 +102,7 @@ internal static class RunCommand
 
             case SubjectInputType.Either:
             {
-                var eitherResult = await FindAndExecuteKnownEither(subject, runArgs, cancellationToken);
+                var eitherResult = await FindAndExecuteKnownEither(subject, runArgs, forceRestore, cancellationToken);
 
                 if (eitherResult is not null)
                     return eitherResult.Value;
@@ -77,7 +114,7 @@ internal static class RunCommand
 
             case SubjectInputType.None:
             {
-                var noneResult = await FindAndExecuteUnknown(runArgs, cancellationToken);
+                var noneResult = await FindAndExecuteUnknown(runArgs, forceRestore, cancellationToken);
 
                 if (noneResult is not null)
                     return noneResult.Value;
@@ -96,6 +133,7 @@ internal static class RunCommand
     private static async Task<int?> FindAndExecuteKnownProject(
         string name,
         string[] runArgs,
+        bool forceRestore,
         CancellationToken cancellationToken)
     {
         if (!name.EndsWith(".csproj"))
@@ -104,7 +142,7 @@ internal static class RunCommand
         var foundPath = FileFinder.FindFile(FileSystem, FileSystem.Directory.GetCurrentDirectory(), [name], true);
 
         if (foundPath is not null)
-            return await Execute(foundPath, runArgs, false, cancellationToken);
+            return await Execute(foundPath, runArgs, false, forceRestore, cancellationToken);
 
         return null;
     }
@@ -112,6 +150,7 @@ internal static class RunCommand
     private static async Task<int?> FindAndExecuteKnownFile(
         string name,
         string[] runArgs,
+        bool forceRestore,
         CancellationToken cancellationToken)
     {
         if (!name.EndsWith(".cs"))
@@ -120,7 +159,7 @@ internal static class RunCommand
         var foundPath = FileFinder.FindFile(FileSystem, FileSystem.Directory.GetCurrentDirectory(), [name], false);
 
         if (foundPath is not null)
-            return await Execute(foundPath, runArgs, true, cancellationToken);
+            return await Execute(foundPath, runArgs, true, forceRestore, cancellationToken);
 
         return null;
     }
@@ -128,6 +167,7 @@ internal static class RunCommand
     private static async Task<int?> FindAndExecuteKnownEither(
         string name,
         string[] runArgs,
+        bool forceRestore,
         CancellationToken cancellationToken)
     {
         var currentDirectory = FileSystem.Directory.GetCurrentDirectory();
@@ -135,17 +175,20 @@ internal static class RunCommand
         var projectPath = FileFinder.FindFile(FileSystem, currentDirectory, [name, $"{name}.csproj"], true);
 
         if (projectPath is not null)
-            return await Execute(projectPath, runArgs, false, cancellationToken);
+            return await Execute(projectPath, runArgs, false, forceRestore, cancellationToken);
 
         var csPath = FileFinder.FindFile(FileSystem, currentDirectory, [name, $"{name}.cs"], false);
 
         if (csPath is not null)
-            return await Execute(csPath, runArgs, true, cancellationToken);
+            return await Execute(csPath, runArgs, true, forceRestore, cancellationToken);
 
         return null;
     }
 
-    private static async Task<int?> FindAndExecuteUnknown(string[] runArgs, CancellationToken cancellationToken)
+    private static async Task<int?> FindAndExecuteUnknown(
+        string[] runArgs,
+        bool forceRestore,
+        CancellationToken cancellationToken)
     {
         // If on nix, we want to duplicate defaultNames for case-sensitivity
         string[] defaultNames = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -154,7 +197,7 @@ internal static class RunCommand
 
         foreach (var name in defaultNames)
         {
-            var result = await FindAndExecuteKnownEither(name, runArgs, cancellationToken);
+            var result = await FindAndExecuteKnownEither(name, runArgs, forceRestore, cancellationToken);
 
             if (result is not null)
                 return result;
@@ -167,6 +210,7 @@ internal static class RunCommand
         IFileInfo path,
         string[] runArgs,
         bool isCsFile,
+        bool forceRestore,
         CancellationToken cancellationToken)
     {
         var sanitizedArgs = SanitizeArgs(runArgs);
@@ -181,22 +225,88 @@ internal static class RunCommand
 
         args.Add(path.FullName);
 
+        // Decide whether the build and/or restore can be skipped based on hashes of their inputs.
+        // '--no-build' implies '--no-restore', so it takes precedence when applicable.
+        RestoreCache.RestoreDecision? restoreDecision = null;
+        BuildCache.BuildDecision? buildDecision = null;
+        var useNoBuild = false;
+        var useNoRestore = false;
+
+        if (!forceRestore)
+        {
+            // The build cache only applies to compiled projects, not file-based (.cs) programs.
+            if (!isCsFile)
+            {
+                buildDecision = BuildCache.Evaluate(FileSystem, path);
+                useNoBuild = buildDecision.CanSkipBuild;
+            }
+
+            if (!useNoBuild)
+            {
+                restoreDecision = RestoreCache.Evaluate(FileSystem, path);
+                useNoRestore = restoreDecision.CanSkipRestore;
+            }
+        }
+
+        if (useNoBuild)
+            args.Add("--no-build");
+        else if (useNoRestore)
+            args.Add("--no-restore");
+
+        LastUsedNoBuild = useNoBuild;
+        LastUsedNoRestore = useNoRestore;
+
         args.Add("--");
         args.AddRange(sanitizedArgs);
 
         if (MockDotnetCli)
+        {
+            // Simulate a successful run: persist the hashes so the next run can skip work.
+            PersistCaches(path, isCsFile, useNoBuild, useNoRestore, restoreDecision, buildDecision);
+
             return 0;
+        }
 
         var atomProcess = Process.Start("dotnet", args);
         await atomProcess.WaitForExitAsync(cancellationToken);
 
+        // If work actually ran and the build succeeded, persist the hashes so the next run can skip it.
+        if (atomProcess.ExitCode is 0)
+            PersistCaches(path, isCsFile, useNoBuild, useNoRestore, restoreDecision, buildDecision);
+
         return atomProcess.ExitCode;
+    }
+
+    private static void PersistCaches(
+        IFileInfo path,
+        bool isCsFile,
+        bool useNoBuild,
+        bool useNoRestore,
+        RestoreCache.RestoreDecision? restoreDecision,
+        BuildCache.BuildDecision? buildDecision)
+    {
+        // A restore ran unless it (or the whole build) was skipped.
+        if (!useNoBuild && !useNoRestore)
+            RestoreCache.Save(FileSystem, restoreDecision ?? RestoreCache.Evaluate(FileSystem, path));
+
+        // A build ran unless it was skipped (build cache applies to compiled projects only).
+        if (!useNoBuild && !isCsFile)
+            BuildCache.Save(FileSystem, buildDecision ?? BuildCache.Evaluate(FileSystem, path));
     }
 
     private static IEnumerable<string> SanitizeArgs(IEnumerable<string> runArgs) =>
         runArgs.Select(arg => arg
             .Replace("\n", string.Empty)
             .Replace("\r", string.Empty));
+
+    private static bool IsRestoreCacheDisabledByEnv()
+    {
+        var value = Environment.GetEnvironmentVariable("ATOM_NO_RESTORE_CACHE");
+
+        return value is { Length: > 0 } &&
+               !string.Equals(value, "0", StringComparison.OrdinalIgnoreCase) &&
+               !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
+    }
 
     private enum SubjectInputType
     {

--- a/src/DecSm.Atom.Tool/FileFinder.cs
+++ b/src/DecSm.Atom.Tool/FileFinder.cs
@@ -57,20 +57,6 @@ public static class FileFinder
         "$RECYCLE.BIN",
     };
 
-    /// <summary>
-    ///     Markers that signal the "Root" of a project.
-    ///     The upward search will stop here.
-    /// </summary>
-    private static readonly HashSet<string> RootMarkers = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ".git",
-        ".slnx",
-        ".sln",
-        "package.json",
-        "go.mod",
-        "Cargo.toml",
-    };
-
     public static IFileInfo? FindFile(
         IFileSystem fileSystem,
         string startDirectory,
@@ -94,9 +80,7 @@ public static class FileFinder
                 return found;
 
             // Stop condition: Don't climb higher than a project root marker
-            if (RootMarkers.Any(marker =>
-                    fileSystem.File.Exists(fileSystem.Path.Combine(currentUp.FullName, marker)) ||
-                    fileSystem.Directory.Exists(fileSystem.Path.Combine(currentUp.FullName, marker))))
+            if (IsRootDirectory(fileSystem, currentUp.FullName))
                 break;
 
             currentUp = currentUp.Parent;
@@ -172,4 +156,26 @@ public static class FileFinder
 
         return null;
     }
+
+    /// <summary>
+    ///     Markers that signal the "Root" of a project.
+    ///     The upward search will stop here.
+    /// </summary>
+    private static readonly HashSet<string> RootMarkers = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".git",
+        ".slnx",
+        ".sln",
+        "package.json",
+        "go.mod",
+        "Cargo.toml",
+    };
+
+    /// <summary>
+    ///     Determines whether the specified directory contains a project root marker
+    ///     (e.g. a <c>.git</c> folder or a solution file).
+    /// </summary>
+    internal static bool IsRootDirectory(IFileSystem fileSystem, string directory) =>
+        RootMarkers.Any(marker => fileSystem.File.Exists(fileSystem.Path.Combine(directory, marker)) ||
+                                  fileSystem.Directory.Exists(fileSystem.Path.Combine(directory, marker)));
 }

--- a/src/DecSm.Atom.Tool/HashCache.cs
+++ b/src/DecSm.Atom.Tool/HashCache.cs
@@ -1,0 +1,81 @@
+namespace DecSm.Atom.Tool;
+
+/// <summary>
+///     Shared low-level helpers for the content-hash based restore/build caches used by
+///     <see cref="Commands.RunCommand" />.
+/// </summary>
+internal static class HashCache
+{
+    /// <summary>
+    ///     Computes a stable SHA256 hash over the given files. The hash incorporates each file's path
+    ///     (relative to <paramref name="projectDir" />) and its raw content, and is order-independent.
+    /// </summary>
+    internal static string ComputeHash(IFileSystem fileSystem, string projectDir, IEnumerable<string> files)
+    {
+        var ordered = files
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static x => x, StringComparer.Ordinal);
+
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+        foreach (var file in ordered)
+        {
+            var relativePath = fileSystem.Path.GetRelativePath(projectDir, file);
+
+            hash.AppendData(Encoding.UTF8.GetBytes(relativePath));
+
+            try
+            {
+                hash.AppendData(fileSystem.File.ReadAllBytes(file));
+            }
+            catch (IOException)
+            {
+                // Treat an unreadable input as empty content rather than failing the run.
+            }
+        }
+
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+
+    /// <summary>
+    ///     Reads the cached hash from the given file, or <c>null</c> if it cannot be read.
+    /// </summary>
+    internal static string? TryRead(IFileSystem fileSystem, string cacheFilePath)
+    {
+        try
+        {
+            return fileSystem
+                .File
+                .ReadAllText(cacheFilePath)
+                .Trim();
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     Persists the computed hash. Best-effort: failures (e.g. concurrent runs, permissions) are ignored.
+    /// </summary>
+    internal static void Write(IFileSystem fileSystem, string cacheFilePath, string hash)
+    {
+        try
+        {
+            var dir = fileSystem.Path.GetDirectoryName(cacheFilePath);
+
+            if (dir is { Length: > 0 })
+                fileSystem.Directory.CreateDirectory(dir);
+
+            fileSystem.File.WriteAllText(cacheFilePath, hash);
+        }
+        catch (IOException)
+        {
+            // Best-effort: a concurrent run or a locked file should never break the build.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Best-effort: missing permissions should never break the build.
+        }
+    }
+}

--- a/src/DecSm.Atom.Tool/RestoreCache.cs
+++ b/src/DecSm.Atom.Tool/RestoreCache.cs
@@ -1,0 +1,100 @@
+namespace DecSm.Atom.Tool;
+
+/// <summary>
+///     Provides a content-hash based cache that lets <see cref="Commands.RunCommand" /> decide whether a
+///     <c>dotnet restore</c> can be skipped (by passing <c>--no-restore</c> to <c>dotnet run</c>).
+/// </summary>
+/// <remarks>
+///     The cache is stored in the project's <c>obj</c> folder (so it is naturally invalidated by
+///     <c>dotnet clean</c>) and keyed by a SHA256 hash of all restore-affecting inputs: the project/file
+///     itself plus any <c>Directory.Build.props</c>, <c>Directory.Build.targets</c>,
+///     <c>Directory.Packages.props</c>, <c>nuget.config</c> and <c>global.json</c> files found while
+///     walking up to the project root.
+/// </remarks>
+internal static class RestoreCache
+{
+    private const string CacheFileName = ".atom-restore.hash";
+
+    private const string RestoreMarkerFileName = "project.assets.json";
+
+    private static readonly string[] RestoreInputFileNames =
+    [
+        "Directory.Build.props",
+        "Directory.Build.targets",
+        "Directory.Packages.props",
+        "nuget.config",
+        "global.json",
+    ];
+
+    /// <summary>
+    ///     Represents the outcome of evaluating the restore cache for a given target.
+    /// </summary>
+    /// <param name="CanSkipRestore">Whether the restore can be skipped because nothing relevant changed.</param>
+    /// <param name="ComputedHash">The freshly computed hash of the restore-affecting inputs.</param>
+    /// <param name="CacheFilePath">The path of the cache file used to persist the hash.</param>
+    internal sealed record RestoreDecision(bool CanSkipRestore, string ComputedHash, string CacheFilePath);
+
+    /// <summary>
+    ///     Computes the restore input hash and compares it against the cached value to determine whether a
+    ///     restore can be skipped.
+    /// </summary>
+    internal static RestoreDecision Evaluate(IFileSystem fileSystem, IFileInfo target)
+    {
+        var projectDir = target.Directory?.FullName ?? fileSystem.Path.GetDirectoryName(target.FullName)!;
+        var objDir = fileSystem.Path.Combine(projectDir, "obj");
+        var cacheFilePath = fileSystem.Path.Combine(objDir, CacheFileName);
+
+        var computedHash = HashCache.ComputeHash(fileSystem,
+            projectDir,
+            CollectRestoreInputs(fileSystem, target, projectDir));
+
+        // A restore can only be skipped if a previous restore actually produced its output (project.assets.json)
+        // and the cached hash matches the current inputs.
+        var canSkip = fileSystem.Directory.Exists(objDir) &&
+                      fileSystem.File.Exists(fileSystem.Path.Combine(objDir, RestoreMarkerFileName)) &&
+                      fileSystem.File.Exists(cacheFilePath) &&
+                      string.Equals(HashCache.TryRead(fileSystem, cacheFilePath),
+                          computedHash,
+                          StringComparison.OrdinalIgnoreCase);
+
+        return new(canSkip, computedHash, cacheFilePath);
+    }
+
+    /// <summary>
+    ///     Persists the computed hash so a subsequent run can skip the restore. Best-effort: failures are ignored.
+    /// </summary>
+    internal static void Save(IFileSystem fileSystem, RestoreDecision decision) =>
+        HashCache.Write(fileSystem, decision.CacheFilePath, decision.ComputedHash);
+
+    /// <summary>
+    ///     Collects the restore-affecting files for the given target by walking up to the project root.
+    /// </summary>
+    internal static List<string> CollectRestoreInputs(IFileSystem fileSystem, IFileInfo target, string projectDir)
+    {
+        var files = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (fileSystem.File.Exists(target.FullName))
+            files.Add(target.FullName);
+
+        var current = fileSystem.DirectoryInfo.New(projectDir);
+
+        while (current is { Exists: true })
+        {
+            foreach (var name in RestoreInputFileNames)
+            {
+                var candidate = fileSystem.Path.Combine(current.FullName, name);
+
+                if (fileSystem.File.Exists(candidate))
+                    files.Add(candidate);
+            }
+
+            // Don't walk higher than the project root.
+            if (FileFinder.IsRootDirectory(fileSystem, current.FullName))
+                break;
+
+            current = current.Parent;
+        }
+
+        return files.ToList();
+    }
+}

--- a/src/DecSm.Atom.Tool/RunArgsFilter.cs
+++ b/src/DecSm.Atom.Tool/RunArgsFilter.cs
@@ -30,17 +30,41 @@ internal class RunArgsFilter(ConsoleAppFilter next) : ConsoleAppFilter(next)
 
         // For other commands, especially the root command that runs an Atom project,
         // adjust the EscapeIndex to correctly pass arguments to the Atom project.
-        // If the first argument is "-p" or "--project", then the project name is the second argument,
-        // and subsequent arguments are for the Atom project. Otherwise, all arguments are for Atom.
+        // Consume any leading tool-level options (the project/file selectors and the
+        // restore-cache flag) so everything after them is forwarded to the Atom project.
+        var escapeIndex = 0;
+        var arguments = context.Arguments;
+
+        while (escapeIndex < arguments.Length)
+        {
+            var current = arguments[escapeIndex];
+
+            if (current is "-p" or "--project" or "-f" or "--file")
+            {
+                // These options take a value, so skip both the option and its value.
+                if (escapeIndex + 1 >= arguments.Length)
+                    break;
+
+                escapeIndex += 2;
+            }
+            else if (current is "--no-restore-cache")
+            {
+                // Boolean flag, skip just the flag itself.
+                escapeIndex += 1;
+            }
+            else
+            {
+                break;
+            }
+        }
+
         await Next.InvokeAsync(new(context.CommandName,
                 context.Arguments,
                 ReadOnlyMemory<string>.Empty, // Raw arguments are not directly used by the next layer after this filter
                 context.State,
                 null,
                 context.CommandDepth,
-                context.Arguments[0] is "-p" or "--project" or "-f" or "--file" && context.Arguments.Length >= 2
-                    ? 2 // Skip "-p" or "--project" or "-f" or "--file" and the project/file name
-                    : 0), // All arguments are for the Atom project
+                escapeIndex),
             cancellationToken);
     }
 }

--- a/src/DecSm.Atom.Tool/_usings.cs
+++ b/src/DecSm.Atom.Tool/_usings.cs
@@ -1,6 +1,8 @@
 ﻿global using System.Diagnostics;
 global using System.IO.Abstractions;
 global using System.Runtime.InteropServices;
+global using System.Security.Cryptography;
+global using System.Text;
 global using ConsoleAppFramework;
 global using DecSm.Atom.Tool;
 global using DecSm.Atom.Tool.Commands;

--- a/tests/DecSm.Atom.Build.Analyzers.Tests/DecSm.Atom.Build.Analyzers.Tests.csproj
+++ b/tests/DecSm.Atom.Build.Analyzers.Tests/DecSm.Atom.Build.Analyzers.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="System.Formats.Asn1" Version="10.0.8" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/DecSm.Atom.Build.Analyzers.Tests/DecSm.Atom.Build.Analyzers.Tests.csproj
+++ b/tests/DecSm.Atom.Build.Analyzers.Tests/DecSm.Atom.Build.Analyzers.Tests.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="System.Formats.Asn1" Version="10.0.8" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/DecSm.Atom.Build.SourceGenerators.Tests/DecSm.Atom.Build.SourceGenerators.Tests.csproj
+++ b/tests/DecSm.Atom.Build.SourceGenerators.Tests/DecSm.Atom.Build.SourceGenerators.Tests.csproj
@@ -9,12 +9,12 @@
     <PackageReference Include="Basic.Reference.Assemblies.Net100" Version="1.8.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Formats.Asn1" Version="10.0.8" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.Atom.Build.SourceGenerators.Tests/DecSm.Atom.Build.SourceGenerators.Tests.csproj
+++ b/tests/DecSm.Atom.Build.SourceGenerators.Tests/DecSm.Atom.Build.SourceGenerators.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies.Net100" Version="1.8.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/tests/DecSm.Atom.Build.SourceGenerators.Tests/Tests/BuildDefinitionSourceGeneratorTests.BuildDefinition_GeneratesSource.verified.txt
+++ b/tests/DecSm.Atom.Build.SourceGenerators.Tests/Tests/BuildDefinitionSourceGeneratorTests.BuildDefinition_GeneratesSource.verified.txt
@@ -17,7 +17,7 @@ using DecSm.Atom.Process;
 namespace TestNamespace;
 
 [JetBrains.Annotations.PublicAPI]
-partial class DefaultTestDefinition : DecSm.Atom.Build.Definition.IBuildDefinition
+partial class DefaultTestDefinition : DecSm.Atom.Build.Definition.IBuildDefinition, DecSm.Atom.Build.Hosting.IConfigureHost
 {
     public DefaultTestDefinition(System.IServiceProvider services) : base(services) { }
 
@@ -65,4 +65,15 @@ partial class DefaultTestDefinition : DecSm.Atom.Build.Definition.IBuildDefiniti
     public override object? AccessParam(string paramName) => throw new System.ArgumentException($"Param with name '{paramName}' is not defined in the build definition.", nameof(paramName));
 
     #endregion Params
+
+    #region Host
+
+    public void ConfigureBuildHost(Microsoft.Extensions.Hosting.IHost builder) { }
+
+    public void ConfigureBuildHostBuilder(Microsoft.Extensions.Hosting.IHostApplicationBuilder builder)
+    {
+        Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<DecSm.Atom.Build.Definition.IBuildDefinition>(builder.Services, static p => (DecSm.Atom.Build.Definition.IBuildDefinition)p.GetRequiredService<DecSm.Atom.Build.Definition.IBuildDefinition>());
+    }
+
+    #endregion Host
 }

--- a/tests/DecSm.Atom.Build.SourceGenerators.Tests/Tests/BuildDefinitionSourceGeneratorTests.MinimalBuildDefinition_WithBaseType_GeneratesSource.verified.txt
+++ b/tests/DecSm.Atom.Build.SourceGenerators.Tests/Tests/BuildDefinitionSourceGeneratorTests.MinimalBuildDefinition_WithBaseType_GeneratesSource.verified.txt
@@ -17,7 +17,7 @@ using DecSm.Atom.Process;
 namespace TestNamespace;
 
 [JetBrains.Annotations.PublicAPI]
-partial class MinimalTestDefinition : DecSm.Atom.Build.Definition.IBuildDefinition
+partial class MinimalTestDefinition : DecSm.Atom.Build.Definition.IBuildDefinition, DecSm.Atom.Build.Hosting.IConfigureHost
 {
     public MinimalTestDefinition(System.IServiceProvider services) : base(services) { }
 
@@ -65,4 +65,15 @@ partial class MinimalTestDefinition : DecSm.Atom.Build.Definition.IBuildDefiniti
     public override object? AccessParam(string paramName) => throw new System.ArgumentException($"Param with name '{paramName}' is not defined in the build definition.", nameof(paramName));
 
     #endregion Params
+
+    #region Host
+
+    public void ConfigureBuildHost(Microsoft.Extensions.Hosting.IHost builder) { }
+
+    public void ConfigureBuildHostBuilder(Microsoft.Extensions.Hosting.IHostApplicationBuilder builder)
+    {
+        Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<DecSm.Atom.Build.Definition.IBuildDefinition>(builder.Services, static p => (DecSm.Atom.Build.Definition.IBuildDefinition)p.GetRequiredService<DecSm.Atom.Build.Definition.IBuildDefinition>());
+    }
+
+    #endregion Host
 }

--- a/tests/DecSm.Atom.Build.Tests/DecSm.Atom.Build.Tests.csproj
+++ b/tests/DecSm.Atom.Build.Tests/DecSm.Atom.Build.Tests.csproj
@@ -13,13 +13,13 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.Atom.Module.DevopsWorkflows.Tests/DecSm.Atom.Module.DevopsWorkflows.Tests.csproj
+++ b/tests/DecSm.Atom.Module.DevopsWorkflows.Tests/DecSm.Atom.Module.DevopsWorkflows.Tests.csproj
@@ -13,13 +13,13 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
+++ b/tests/DecSm.Atom.Module.GithubWorkflows.Tests/DecSm.Atom.Module.GithubWorkflows.Tests.csproj
@@ -13,13 +13,13 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.Atom.Process.Tests/DecSm.Atom.Process.Tests.csproj
+++ b/tests/DecSm.Atom.Process.Tests/DecSm.Atom.Process.Tests.csproj
@@ -9,11 +9,11 @@
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.Atom.SemanticVersion.Tests/DecSm.Atom.SemanticVersion.Tests.csproj
+++ b/tests/DecSm.Atom.SemanticVersion.Tests/DecSm.Atom.SemanticVersion.Tests.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.Atom.Tool.Tests/DecSm.Atom.Tool.Tests.csproj
+++ b/tests/DecSm.Atom.Tool.Tests/DecSm.Atom.Tool.Tests.csproj
@@ -11,12 +11,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.Atom.Tool.Tests/RunCommandTests.cs
+++ b/tests/DecSm.Atom.Tool.Tests/RunCommandTests.cs
@@ -9,6 +9,7 @@ internal sealed class RunCommandTests
         _fs = new();
         RunCommand.FileSystem = _fs;
         RunCommand.MockDotnetCli = true;
+        Environment.SetEnvironmentVariable("ATOM_NO_RESTORE_CACHE", null);
     }
 
     [TearDown]
@@ -16,6 +17,7 @@ internal sealed class RunCommandTests
     {
         RunCommand.FileSystem = new FileSystem();
         RunCommand.MockDotnetCli = false;
+        Environment.SetEnvironmentVariable("ATOM_NO_RESTORE_CACHE", null);
     }
 
     private MockFileSystem _fs = null!;
@@ -295,5 +297,203 @@ internal sealed class RunCommandTests
             CancellationToken.None);
 
         result.ShouldBe(0);
+    }
+
+    [Test]
+    public async Task Handle_CacheMiss_PerformsRestore_AndWritesCache()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        var result = await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoRestore.ShouldBeFalse();
+
+        _fs
+            .File
+            .Exists(P("work", "obj", ".atom-restore.hash"))
+            .ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Handle_CacheHit_SkipsRestore()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        // First run performs a restore and writes the cache.
+        await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        // Simulate the restore output that 'dotnet restore' would produce.
+        _fs.AddFile(P("work", "obj", "project.assets.json"), new(""));
+
+        // Second run with unchanged inputs should skip the restore.
+        var result = await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoRestore.ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Handle_CacheInvalidated_WhenInputChanges_PerformsRestore()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        await RunCommand.Handle([], string.Empty, CancellationToken.None);
+        _fs.AddFile(P("work", "obj", "project.assets.json"), new(""));
+
+        // Change the project file content - the cached hash should no longer match.
+        _fs.File.WriteAllText(P("work", "_atom.csproj"), "<Project></Project>");
+
+        var result = await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoRestore.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Handle_CacheInvalidated_WhenDirectoryPackagesChanges_PerformsRestore()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.AddFile(P("work", "Directory.Packages.props"), new("<Project></Project>"));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        await RunCommand.Handle([], string.Empty, CancellationToken.None);
+        _fs.AddFile(P("work", "obj", "project.assets.json"), new(""));
+
+        // A walked-up restore input changed - restore should run again.
+        _fs.File.WriteAllText(P("work", "Directory.Packages.props"), "<Project><ItemGroup /></Project>");
+
+        var result = await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoRestore.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Handle_NoRestoreCacheFlag_AlwaysPerformsRestore()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        await RunCommand.Handle([], string.Empty, CancellationToken.None);
+        _fs.AddFile(P("work", "obj", "project.assets.json"), new(""));
+
+        // Even though the cache would normally hit, the opt-out forces a restore.
+        var result = await RunCommand.Handle([], string.Empty, true, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoRestore.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Handle_NoRestoreCacheEnvVar_AlwaysPerformsRestore()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        await RunCommand.Handle([], string.Empty, CancellationToken.None);
+        _fs.AddFile(P("work", "obj", "project.assets.json"), new(""));
+
+        Environment.SetEnvironmentVariable("ATOM_NO_RESTORE_CACHE", "1");
+
+        var result = await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoRestore.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Handle_BuildCacheMiss_PerformsBuild_AndWritesCache()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        var result = await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoBuild.ShouldBeFalse();
+
+        _fs
+            .File
+            .Exists(P("work", "obj", ".atom-build.hash"))
+            .ShouldBeTrue();
+    }
+
+    [Test]
+    public async Task Handle_BuildCacheHit_SkipsBuild()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        // First run builds and writes the cache.
+        await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        // Simulate the build output that 'dotnet build' would produce.
+        _fs.AddFile(P("work", "bin", "Debug", "net10.0", "_atom.dll"), new(""));
+
+        // Second run with unchanged inputs should skip the build entirely.
+        var result = await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoBuild.ShouldBeTrue();
+        RunCommand.LastUsedNoRestore.ShouldBeFalse(); // --no-build supersedes --no-restore
+    }
+
+    [Test]
+    public async Task Handle_BuildCacheInvalidated_WhenSourceChanges_PerformsBuild()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.AddFile(P("work", "Program.cs"), new("// v1"));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        await RunCommand.Handle([], string.Empty, CancellationToken.None);
+        _fs.AddFile(P("work", "bin", "Debug", "net10.0", "_atom.dll"), new(""));
+
+        // A source file changed - the build can no longer be skipped.
+        _fs.File.WriteAllText(P("work", "Program.cs"), "// v2");
+
+        var result = await RunCommand.Handle([], string.Empty, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoBuild.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task Handle_NoRestoreCacheFlag_AlsoForcesBuild()
+    {
+        var workDir = P("work");
+        _fs.AddDirectory(workDir);
+        _fs.AddFile(P("work", "_atom.csproj"), new(""));
+        _fs.Directory.SetCurrentDirectory(workDir);
+
+        await RunCommand.Handle([], string.Empty, CancellationToken.None);
+        _fs.AddFile(P("work", "bin", "Debug", "net10.0", "_atom.dll"), new(""));
+
+        // Even though the build cache would hit, the opt-out forces a full build.
+        var result = await RunCommand.Handle([], string.Empty, true, CancellationToken.None);
+
+        result.ShouldBe(0);
+        RunCommand.LastUsedNoBuild.ShouldBeFalse();
     }
 }

--- a/tests/DecSm.Atom.Workflows.Tests/DecSm.Atom.Workflows.Tests.csproj
+++ b/tests/DecSm.Atom.Workflows.Tests/DecSm.Atom.Workflows.Tests.csproj
@@ -9,13 +9,13 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.StructuredText.AzureDevopsPipelines.Tests/DecSm.StructuredText.AzureDevopsPipelines.Tests.csproj
+++ b/tests/DecSm.StructuredText.AzureDevopsPipelines.Tests/DecSm.StructuredText.AzureDevopsPipelines.Tests.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.StructuredText.GithubActions.Tests/DecSm.StructuredText.GithubActions.Tests.csproj
+++ b/tests/DecSm.StructuredText.GithubActions.Tests/DecSm.StructuredText.GithubActions.Tests.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.StructuredText.Tests/DecSm.StructuredText.Tests.csproj
+++ b/tests/DecSm.StructuredText.Tests/DecSm.StructuredText.Tests.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DecSm.atom.FileSystem.Tests/DecSm.Atom.FileSystem.Tests.csproj
+++ b/tests/DecSm.atom.FileSystem.Tests/DecSm.Atom.FileSystem.Tests.csproj
@@ -9,13 +9,13 @@
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.17.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request primarily updates package dependencies across the solution to keep them current and improve compatibility, particularly for Roslyn and test-related packages. It also makes minor adjustments to code logic in the build and test helpers, mainly around GitHub token permissions and test execution error handling.

**Dependency Updates**

* Updated Roslyn-related NuGet packages (`Microsoft.CodeAnalysis.CSharp`, `Microsoft.CodeAnalysis.Workspaces.Common`, and related test packages) from version 5.0.0 to 5.3.0 in both main projects and test projects for better compatibility and feature support. [[1]](diffhunk://#diff-0e684d0bf7580dbcde106e234012a9089dfe2c058545b289a9d996c015300c87L19-R20) [[2]](diffhunk://#diff-1f4bdc2aa41b511b3b876021cc5618de630ccf445ba8a60f4f1644f00c7016a7L15-R15) [[3]](diffhunk://#diff-4ca38fe411bc64f1ceecca1a3b5068fa628782b198e06554982a7b0d6121ac42L11-R12)
* Bumped `Azure.Storage.Blobs` from 12.28.0 to 12.29.0 in the Azure Storage module for the latest features and fixes.
* Upgraded various test-related dependencies (`Microsoft.NET.Test.Sdk`, `Verify.NUnit`, `NUnit.Analyzers`, etc.) across all test projects to their latest versions, improving test infrastructure and analyzer accuracy. [[1]](diffhunk://#diff-a76ba726a7a9667d67893c62b69c982fcb85986a62ed932b266b9ae5f7cf2dd1L12-R25) [[2]](diffhunk://#diff-4379043c4c4fa0de433e397f572dcf25eb0c4d35268e89c90a56b82cff0c17cdL16-R30) [[3]](diffhunk://#diff-1e1ef0052986bbbfbfd77d48f266c4eea5d7ce1c0d5e07cd7211d87a72087c6cL16-R30) [[4]](diffhunk://#diff-560939b5207f598e0a86b51848c3b8a688d0042fdeeab2ac12f9ed946521041cL16-R30) [[5]](diffhunk://#diff-55cdf3f5fe420f54083eaf553d1f7a0dc7fd44622daf4b5a686a7b6b4a4067f3L12-R16) [[6]](diffhunk://#diff-55cdf3f5fe420f54083eaf553d1f7a0dc7fd44622daf4b5a686a7b6b4a4067f3L28-R28) [[7]](diffhunk://#diff-566e2e8c8a6b08cd8b1aac53d691521a21005ba7dd9405cc4ecf197e4e854e7bL10-R14) [[8]](diffhunk://#diff-566e2e8c8a6b08cd8b1aac53d691521a21005ba7dd9405cc4ecf197e4e854e7bL26-R26) [[9]](diffhunk://#diff-3dda9f097f64ee6854278d01d3c28c52cc43108495d9b3bd1d9f74e527924833L14-R27) [[10]](diffhunk://#diff-473d038a473111afc4a080040ed9e588afdd3878a02e3fd7dafeaca918f14711L12-R18) [[11]](diffhunk://#diff-473d038a473111afc4a080040ed9e588afdd3878a02e3fd7dafeaca918f14711L30-R30) [[12]](diffhunk://#diff-bb8b763ec3b2c2f54b6e336cdb86057839b3f3d2d22d573dd41838b63e69d6a1L10-R14) [[13]](diffhunk://#diff-bb8b763ec3b2c2f54b6e336cdb86057839b3f3d2d22d573dd41838b63e69d6a1L26-R26) [[14]](diffhunk://#diff-6f69703a0d248e23c377ff94eac7aaa654604b94144354a9f8b26bbfc5a6d5efL10-R14) [[15]](diffhunk://#diff-6f69703a0d248e23c377ff94eac7aaa654604b94144354a9f8b26bbfc5a6d5efL26-R26) [[16]](diffhunk://#diff-376256163dce5ee464ca1e1ecf04df898b7e07256c7ae2052b92557ab053990aL10-R14)

**Build and Workflow Adjustments**

* Changed the way GitHub token permissions are set in the build interface to use a more consistent API (`BuildOptions.Github.TokenPermissions.Set`).

**Test Helper Logic**

* Adjusted error handling in `IDotnetTestHelper.cs`:
  - Allowed failed results for one test execution scenario to make the process more tolerant of specific errors.
  - Set `AllowFailedResult` to `false` for the report generator tool execution, making this step stricter and likely to fail on errors.