### PR TITLE
Improvement/wait for copilot

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -124,7 +124,7 @@ dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
 
 # .NET code quality rules
-dotnet_code_quality.DecSm_Analyzers_ValidPublicApiAttributes = UnstableAPI
+dotnet_code_quality.Invex_RepoUtils_PublicApiAnalyzers_ValidPublicApiAttributes = UnstableAPI
 
 [*.{received,verified}.{txt,xml,json}]
 # Verify settings

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -247,7 +247,7 @@ jobs:
   PublishDocs:
     permissions:
       contents: write
-    needs: [ BuildDocs, SetupBuildInfo ]
+    needs: [ SetupBuildInfo, BuildDocs ]
     if: contains(needs.SetupBuildInfo.outputs.build-version, '-') == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/Validate.yml
+++ b/.github/workflows/Validate.yml
@@ -169,3 +169,24 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.number }}
 
+  WaitForCopilotReview:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET 10.0.x
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: WaitForCopilotReview
+        id: WaitForCopilotReview
+        run: dotnet run --project _atom/_atom.csproj -- WaitForCopilotReview --skip --headless
+        env:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.number }}
+

--- a/_atom/IBuild.cs
+++ b/_atom/IBuild.cs
@@ -13,7 +13,8 @@ internal interface IBuild : IWorkflowBuildDefinition,
     IDeployTargets,
     IApproveDependabotPr,
     ICheckPrForBreakingChanges,
-    IDocTargets
+    IDocTargets,
+    IWaitForCopilotReview
 {
     static readonly string[] PlatformNames =
     [
@@ -112,6 +113,15 @@ internal interface IBuild : IWorkflowBuildDefinition,
                             TextExpressions.Github.GithubEvent["number"]),
                         BuildOptions.Target.RunIfWorkflowCondition(
                             TextExpressions.Github.GithubEventName.EqualToString("pull_request")),
+                    ],
+                },
+                new(nameof(WaitForCopilotReview))
+                {
+                    Options =
+                    [
+                        BuildOptions.Inject.Secret(nameof(GithubToken)),
+                        BuildOptions.Inject.Param(nameof(PullRequestNumber),
+                            TextExpressions.Github.GithubEvent["number"]),
                     ],
                 },
             ],

--- a/_atom/RepoUtils/IApiSurfaceHelper.cs
+++ b/_atom/RepoUtils/IApiSurfaceHelper.cs
@@ -1,10 +1,10 @@
-namespace Atom.Targets;
+namespace Atom.RepoUtils;
 
-public sealed record BreakingChanges(IReadOnlyList<Change> MajorChanges, IReadOnlyList<Change> MinorChanges);
+internal sealed record BreakingChanges(IReadOnlyList<Change> MajorChanges, IReadOnlyList<Change> MinorChanges);
 
-public sealed record Change(RootedPath Path, List<Line> AddedLines, List<Line> DeletedLines);
+internal sealed record Change(RootedPath Path, List<Line> AddedLines, List<Line> DeletedLines);
 
-public interface IApiSurfaceHelper : IBuildAccessor
+internal interface IApiSurfaceHelper : IBuildAccessor
 {
     BreakingChanges IdentifyBreakingChanges(
         SemVer oldVersion,

--- a/_atom/RepoUtils/IApproveDependabotPr.cs
+++ b/_atom/RepoUtils/IApproveDependabotPr.cs
@@ -1,6 +1,6 @@
-namespace Atom.Targets;
+namespace Atom.RepoUtils;
 
-public interface IApproveDependabotPr : IGithubHelper, IPullRequestHelper
+internal interface IApproveDependabotPr : IGithubHelper, IPullRequestHelper
 {
     const string DependabotActorName = "dependabot[bot]";
 

--- a/_atom/RepoUtils/ICheckPrForBreakingChanges.cs
+++ b/_atom/RepoUtils/ICheckPrForBreakingChanges.cs
@@ -1,8 +1,8 @@
-namespace Atom.Targets;
+namespace Atom.RepoUtils;
 
-public sealed record ReleaseInfo(string CommitHash, SemVer Version);
+internal sealed record ReleaseInfo(string CommitHash, SemVer Version);
 
-public interface ICheckPrForBreakingChanges : IGithubHelper, IPullRequestHelper, ISetupBuildInfo, IApiSurfaceHelper
+internal interface ICheckPrForBreakingChanges : IGithubHelper, IPullRequestHelper, ISetupBuildInfo, IApiSurfaceHelper
 {
     private RootedPath[] FilesToCheck =>
         RootedFileSystem

--- a/_atom/RepoUtils/ICopilotReviewHelper.cs
+++ b/_atom/RepoUtils/ICopilotReviewHelper.cs
@@ -1,0 +1,191 @@
+namespace Atom.RepoUtils;
+
+/// <summary>
+///     Provides functionality for waiting until GitHub Copilot has finished reviewing a pull request.
+///     GitHub does not currently expose a native way to block auto-merge on a Copilot review, so this
+///     helper polls the pull request's review state until Copilot's review has landed (or a timeout
+///     elapses).
+/// </summary>
+internal interface ICopilotReviewHelper : IBuildAccessor
+{
+    /// <summary>
+    ///     The default login of the GitHub Copilot pull request reviewer bot.
+    /// </summary>
+    const string DefaultCopilotReviewerLogin = "Copilot";
+
+    /// <summary>
+    ///     Polls the supplied pull request until GitHub Copilot has finished reviewing it.
+    /// </summary>
+    /// <param name="pullRequestNumber">The number of the pull request to wait on.</param>
+    /// <param name="githubToken">The GitHub token used to authenticate the GraphQL requests.</param>
+    /// <param name="copilotReviewerLogin">The login of the Copilot reviewer bot to match against.</param>
+    /// <param name="timeout">The maximum amount of time to wait for Copilot to finish reviewing.</param>
+    /// <param name="pollInterval">The delay between successive polls of the pull request state.</param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <returns>
+    ///     <see langword="true" /> when Copilot has finished reviewing the pull request; <see langword="false" />
+    ///     when Copilot was never requested as a reviewer and therefore there was nothing to wait for.
+    /// </returns>
+    /// <exception cref="StepFailedException">
+    ///     Thrown when Copilot does not finish reviewing within <paramref name="timeout" />.
+    /// </exception>
+    /// <remarks>
+    ///     While Copilot is reviewing it remains a pending review request on the pull request. Once it is
+    ///     done it is removed from the pending review requests and a review authored by the Copilot bot
+    ///     appears. The method therefore considers the review complete when Copilot is no longer pending
+    ///     and a review from it exists.
+    /// </remarks>
+    async Task<bool> WaitForCopilotReviewToComplete(
+        int pullRequestNumber,
+        string githubToken,
+        string copilotReviewerLogin,
+        TimeSpan timeout,
+        TimeSpan pollInterval,
+        CancellationToken cancellationToken)
+    {
+        var owner = Github.Variables.RepositoryOwner;
+
+        // The repository variable is in "owner/name" form; we only need the repository name here.
+        var repository = Github.Variables
+            .Repository
+            .Split('/')
+            .Last();
+
+        Logger.LogInformation("Waiting for Copilot ('{CopilotLogin}') to finish reviewing pull request #{PullRequest}.",
+            copilotReviewerLogin,
+            pullRequestNumber);
+
+        // Establish an authenticated GraphQL connection to the GitHub API.
+        var productHeader = new ProductHeaderValue("Atom");
+        var connection = new Connection(productHeader, new InMemoryCredentialStore(githubToken));
+
+        var deadline = DateTimeOffset.UtcNow + timeout;
+
+        while (true)
+        {
+            var (isPending, hasReview) = await QueryCopilotReviewState(connection,
+                repository,
+                owner,
+                pullRequestNumber,
+                copilotReviewerLogin,
+                cancellationToken);
+
+            // Copilot was never requested and has not left a review: there is nothing to wait for.
+            if (!isPending && !hasReview)
+            {
+                Logger.LogInformation(
+                    "Copilot was not requested as a reviewer on pull request #{PullRequest}. Nothing to wait for.",
+                    pullRequestNumber);
+
+                return false;
+            }
+
+            // Copilot has submitted its review and is no longer pending: the review is complete.
+            if (hasReview && !isPending)
+            {
+                Logger.LogInformation("Copilot has finished reviewing pull request #{PullRequest}.", pullRequestNumber);
+
+                return true;
+            }
+
+            if (DateTimeOffset.UtcNow >= deadline)
+                throw new StepFailedException(
+                    $"Timed out after {timeout} waiting for Copilot to finish reviewing pull request #{pullRequestNumber}.");
+
+            Logger.LogInformation("Copilot review of pull request #{PullRequest} is still pending. Waiting {Interval}.",
+                pullRequestNumber,
+                pollInterval);
+
+            await Task.Delay(pollInterval, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    ///     Queries the current Copilot review state of a pull request.
+    /// </summary>
+    /// <param name="connection">The authenticated GraphQL connection to use.</param>
+    /// <param name="repository">The name of the repository the pull request belongs to.</param>
+    /// <param name="owner">The owner (user or organization) of the repository.</param>
+    /// <param name="pullRequestNumber">The number of the pull request to inspect.</param>
+    /// <param name="copilotReviewerLogin">The login of the Copilot reviewer bot to match against.</param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <returns>
+    ///     A tuple describing whether Copilot is currently a pending review request and whether a review
+    ///     authored by Copilot already exists.
+    /// </returns>
+    /// <exception cref="StepFailedException">Thrown when the pull request cannot be resolved.</exception>
+    private async Task<(bool IsPending, bool HasReview)> QueryCopilotReviewState(
+        Connection connection,
+        string repository,
+        string owner,
+        int pullRequestNumber,
+        string copilotReviewerLogin,
+        CancellationToken cancellationToken)
+    {
+        var query = new Query()
+            .Repository(repository, owner)
+            .PullRequest(pullRequestNumber)
+            .Select(p => new ReviewState
+            {
+                // Logins of the reviewers that still have a pending review request on the pull request.
+                PendingReviewerLogins = p
+                    .ReviewRequests(100, null, null, null)
+                    .Nodes
+                    .Select(rr => rr.RequestedReviewer.Switch<string?>(when => when
+                        .User(user => user.Login)
+                        .Bot(bot => bot.Login)
+                        .Mannequin(mannequin => mannequin.Login)))
+                    .ToList(),
+                // Logins of the authors of any reviews that have already been submitted.
+                ReviewAuthorLogins = p
+                    .Reviews(100, null, null, null, null, null)
+                    .Nodes
+                    .Select(review => review.Author.Login)
+                    .ToList(),
+            })
+            .Compile();
+
+        var result = await connection.Run(query, cancellationToken: cancellationToken);
+
+        if (result is null)
+            throw new StepFailedException($"Could not find pull request #{pullRequestNumber}.");
+
+        Logger.LogInformation(
+            "Pull request #{PullRequest} review state. Pending reviewers: [{PendingReviewers}]. Review authors: [{ReviewAuthors}].",
+            pullRequestNumber,
+            string.Join(", ", result.PendingReviewerLogins.Where(login => login is not null)),
+            string.Join(", ", result.ReviewAuthorLogins));
+
+        // GitHub Copilot's reviewer bot surfaces with a login such as "copilot-pull-request-reviewer"
+        // (the "Copilot" shown in the UI is only the display name), so match on a case-insensitive
+        // substring rather than an exact login to remain robust across these representations.
+        var isPending = result.PendingReviewerLogins.Any(login => IsCopilotLogin(login, copilotReviewerLogin));
+
+        var hasReview = result.ReviewAuthorLogins.Any(login => IsCopilotLogin(login, copilotReviewerLogin));
+
+        return (isPending, hasReview);
+
+        static bool IsCopilotLogin(string? login, string copilotReviewerLogin)
+        {
+            return login is not null &&
+                   (login.Contains(copilotReviewerLogin, StringComparison.OrdinalIgnoreCase) ||
+                    copilotReviewerLogin.Contains(login, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    /// <summary>
+    ///     The projected GraphQL result describing the review state of a pull request.
+    /// </summary>
+    private sealed class ReviewState
+    {
+        /// <summary>
+        ///     The logins of the reviewers that still have a pending review request on the pull request.
+        /// </summary>
+        public required List<string?> PendingReviewerLogins { get; init; }
+
+        /// <summary>
+        ///     The logins of the authors of the reviews that have already been submitted.
+        /// </summary>
+        public required List<string> ReviewAuthorLogins { get; init; }
+    }
+}

--- a/_atom/RepoUtils/IDocFxHelper.cs
+++ b/_atom/RepoUtils/IDocFxHelper.cs
@@ -1,0 +1,278 @@
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Atom.RepoUtils;
+
+/// <summary>
+///     Provides functionality for generating, serving, and publishing
+///     <see href="https://dotnet.github.io/docfx/">DocFX</see> documentation for the repository.
+///     The helper builds the static documentation site, can host it locally for previewing, and
+///     publishes the generated output to a project's <c>gh-pages</c> branch for GitHub Pages hosting.
+/// </summary>
+internal interface IDocFxHelper : IDotnetCliHelper, IGithubHelper, ISetupBuildInfo
+{
+    /// <summary>
+    ///     The name of the build artifact (and corresponding output sub-directory) that contains the
+    ///     generated DocFX site. Used both as the destination folder under the publish directory and as
+    ///     the artifact name resolved under the artifacts directory when publishing.
+    /// </summary>
+    const string GeneratedDocsArtifactName = "GeneratedDocs";
+
+    /// <summary>
+    ///     Builds the DocFX documentation site and copies the generated output into the publish
+    ///     directory under <see cref="GeneratedDocsArtifactName" />.
+    /// </summary>
+    /// <param name="projectsToPrebuild">
+    ///     An optional collection of projects to build in <c>Release</c> configuration before running
+    ///     DocFX. This ensures any metadata DocFX extracts from the compiled assemblies and XML
+    ///     documentation is up to date. When <see langword="null" />, no projects are pre-built.
+    /// </param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <remarks>
+    ///     On .NET 10 or newer the tool is executed directly via <c>dotnet tool exec docfx</c>. On
+    ///     earlier runtimes the DocFX global tool is updated/installed first and then invoked via
+    ///     <c>dotnet docfx</c>. The site is generated into the <c>_site</c> directory beneath the Atom
+    ///     root before being copied to the publish directory.
+    /// </remarks>
+    async Task BuildDocFxDocs(
+        IEnumerable<RootedPath>? projectsToPrebuild = null,
+        CancellationToken cancellationToken = default)
+    {
+        // First, build projects in release mode
+        foreach (var project in projectsToPrebuild ?? Array.Empty<RootedPath>())
+            await DotnetCli.Build([project],
+                new()
+                {
+                    Configuration = "Release",
+                },
+                cancellationToken: cancellationToken);
+
+        var siteDirectory = RootedFileSystem.AtomRootDirectory / "_site";
+
+        // If .NET 10, we can just do dotnet tool exec docfx
+        if (RuntimeInformation.FrameworkDescription.StartsWith(".NET 10"))
+        {
+            await ProcessRunner.RunAsync(new("dotnet", "tool exec -y docfx")
+                {
+                    WorkingDirectory = RootedFileSystem.AtomRootDirectory,
+                },
+                cancellationToken);
+        }
+        else
+        {
+            // Otherwise, we need to restore the tools and run docfx
+            Logger.LogInformation("Acquiring DocFX tool...");
+
+            await ProcessRunner.RunAsync(new("dotnet", "tool update docfx -g")
+                {
+                    WorkingDirectory = RootedFileSystem.AtomRootDirectory,
+                },
+                cancellationToken);
+
+            Logger.LogInformation("Running DocFX...");
+
+            await ProcessRunner.RunAsync(new("dotnet", "docfx")
+                {
+                    WorkingDirectory = RootedFileSystem.AtomRootDirectory,
+                },
+                cancellationToken);
+        }
+
+        Logger.LogInformation("DocFX site generated at {Path}", siteDirectory);
+
+        // Copy the generated site to the publish directory
+        await CopyDirectory(siteDirectory, RootedFileSystem.AtomPublishDirectory / GeneratedDocsArtifactName);
+    }
+
+    /// <summary>
+    ///     Serves the generated DocFX site locally for previewing, hosting it at
+    ///     <c>http://localhost:8080</c> until the operation is cancelled.
+    /// </summary>
+    /// <param name="cancellationToken">
+    ///     A token used to stop the local server. Cancellation is handled gracefully and results in the
+    ///     server shutting down without surfacing an error.
+    /// </param>
+    /// <remarks>
+    ///     This serves the contents of the <c>_site</c> directory beneath the Atom root, so
+    ///     <see cref="BuildDocFxDocs" /> should be run beforehand to ensure the site exists.
+    /// </remarks>
+    async Task ServeDocFxDocs(CancellationToken cancellationToken = default)
+    {
+        Logger.LogInformation("Serving DocFX site at http://localhost:8080/README.html");
+        Logger.LogInformation("Press Ctrl+C to stop the server.");
+
+        try
+        {
+            await ProcessRunner.RunAsync(new("dotnet",
+                    $"tool exec docfx -- serve {RootedFileSystem.AtomRootDirectory / "_site"} --port 8080"),
+                cancellationToken);
+        }
+        catch (TaskCanceledException)
+        {
+            Logger.LogInformation("DocFX server stopped.");
+        }
+    }
+
+    /// <summary>
+    ///     Publishes a previously generated DocFX site to the repository's <c>gh-pages</c> branch,
+    ///     making it available via GitHub Pages.
+    /// </summary>
+    /// <param name="githubToken">
+    ///     The GitHub token used to authenticate the push. When the remote uses HTTPS, the token is
+    ///     injected into the remote URL as an <c>x-access-token</c> credential.
+    /// </param>
+    /// <param name="generatedDocsArtifactName">
+    ///     The name of the artifact (under the artifacts directory) that contains the generated site to
+    ///     publish, typically <see cref="GeneratedDocsArtifactName" />.
+    /// </param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <remarks>
+    ///     The site is published by creating a fresh orphan <c>gh-pages</c> branch in a temporary
+    ///     directory, committing the generated files, and force-pushing to the origin remote. The
+    ///     temporary checkout is always removed once the operation completes, even on failure.
+    /// </remarks>
+    /// <exception cref="StepFailedException">
+    ///     Thrown when the generated site artifact does not exist, or when the origin remote URL cannot
+    ///     be determined.
+    /// </exception>
+    async Task PublishDocFxDocsToGithub(
+        string githubToken,
+        string generatedDocsArtifactName,
+        CancellationToken cancellationToken = default)
+    {
+        var siteArtifact = RootedFileSystem.AtomArtifactsDirectory / generatedDocsArtifactName;
+
+        if (!RootedFileSystem.Directory.Exists(siteArtifact))
+            throw new StepFailedException("Site directory '_site' does not exist. Run BuildDocs first.");
+
+        // Create a fresh temporary directory for the gh-pages checkout
+        var tempDir = RootedFileSystem.AtomTempDirectory / "gh-pages-temp";
+
+        if (RootedFileSystem.Directory.Exists(tempDir))
+            ForceDeleteDirectory(tempDir);
+
+        RootedFileSystem.Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            // Init a fresh repo
+            await ProcessRunner.RunAsync(new("git", "init")
+                {
+                    WorkingDirectory = tempDir,
+                },
+                cancellationToken);
+
+            await ProcessRunner.RunAsync(new("git", "checkout --orphan gh-pages")
+                {
+                    WorkingDirectory = tempDir,
+                },
+                cancellationToken);
+
+            // Set git user details for the commit
+            await ProcessRunner.RunAsync(new("git", ["config", "user.name", "\"github-actions[bot]\""])
+                {
+                    WorkingDirectory = tempDir,
+                },
+                cancellationToken);
+
+            await ProcessRunner.RunAsync(new("git",
+                    ["config", "user.email", "\"41898282+github-actions[bot]@users.noreply.github.com\""])
+                {
+                    WorkingDirectory = tempDir,
+                },
+                cancellationToken);
+
+            // Copy the generated site to the gh-pages branch
+            await CopyDirectory(siteArtifact, tempDir);
+
+            // Commit
+            await ProcessRunner.RunAsync(new("git", "add .")
+                {
+                    WorkingDirectory = tempDir,
+                },
+                cancellationToken);
+
+            await ProcessRunner.RunAsync(new("git", ["commit", "-m", "\"Deploy documentation to GitHub Pages\""])
+                {
+                    WorkingDirectory = tempDir,
+                },
+                cancellationToken);
+
+            // Get the remote URL from the main repo
+            var remoteResult = await ProcessRunner.RunAsync(new("git", "remote get-url origin")
+                {
+                    WorkingDirectory = RootedFileSystem.AtomRootDirectory,
+                    OutputLogLevel = LogLevel.Debug,
+                },
+                cancellationToken);
+
+            var remoteUrl = remoteResult.Output.Trim();
+
+            if (string.IsNullOrEmpty(remoteUrl))
+                throw new StepFailedException("Could not determine git remote URL.");
+
+            // Inject the GitHub token into the remote URL for authentication
+            if (!string.IsNullOrEmpty(githubToken) && remoteUrl.StartsWith("https://"))
+                remoteUrl = remoteUrl.Replace("https://", $"https://x-access-token:{githubToken}@");
+
+            // Force push to gh-pages
+            Logger.LogInformation("Pushing to gh-pages branch...");
+
+            await ProcessRunner.RunAsync(new("git", ["push", "--force", remoteUrl, "gh-pages"])
+                {
+                    WorkingDirectory = tempDir,
+                },
+                cancellationToken);
+
+            Logger.LogInformation("Documentation published to GitHub Pages successfully.");
+        }
+        finally
+        {
+            // Cleanup
+            if (RootedFileSystem.Directory.Exists(tempDir))
+                ForceDeleteDirectory(tempDir);
+        }
+    }
+
+    /// <summary>
+    ///     Copies all files and subdirectories from a source directory to a destination directory.
+    /// </summary>
+    /// <param name="sourceDirectory">The source directory.</param>
+    /// <param name="destinationDirectory">The destination directory.</param>
+    async Task CopyDirectory(RootedPath sourceDirectory, RootedPath destinationDirectory)
+    {
+        // Ensure the destination directory exists
+        RootedFileSystem.Directory.CreateDirectory(destinationDirectory);
+
+        // Copy all files
+        foreach (var file in RootedFileSystem
+                     .Directory
+                     .GetFiles(sourceDirectory)
+                     .Select(RootedFileSystem.CreateRootedPath))
+            RootedFileSystem.File.Copy(file, destinationDirectory / RootedFileSystem.Path.GetFileName(file), true);
+
+        // Recursively copy all subdirectories
+        foreach (var directory in RootedFileSystem
+                     .Directory
+                     .GetDirectories(sourceDirectory)
+                     .Select(RootedFileSystem.CreateRootedPath))
+            await CopyDirectory(directory, destinationDirectory / RootedFileSystem.Path.GetFileName(directory));
+    }
+
+    /// <summary>
+    ///     Recursively removes read-only attributes and deletes a directory.
+    ///     Git object files are marked read-only, so a plain Directory.Delete fails.
+    /// </summary>
+    /// <param name="path">The path of the directory to delete.</param>
+    void ForceDeleteDirectory(string path)
+    {
+        foreach (var file in RootedFileSystem.Directory.GetFiles(path, "*", SearchOption.AllDirectories))
+        {
+            var attrs = RootedFileSystem.File.GetAttributes(file);
+
+            if (attrs.HasFlag(FileAttributes.ReadOnly))
+                RootedFileSystem.File.SetAttributes(file, attrs & ~FileAttributes.ReadOnly);
+        }
+
+        RootedFileSystem.Directory.Delete(path, true);
+    }
+}

--- a/_atom/RepoUtils/IPullRequestHelper.cs
+++ b/_atom/RepoUtils/IPullRequestHelper.cs
@@ -1,6 +1,6 @@
-namespace Atom.Targets;
+namespace Atom.RepoUtils;
 
-public interface IPullRequestHelper : IBuildAccessor
+internal interface IPullRequestHelper : IBuildAccessor
 {
     [ParamDefinition("pull-request-number", "The pull request number to approve.")]
     int PullRequestNumber => GetParam(() => PullRequestNumber);

--- a/_atom/RepoUtils/IWaitForCopilotReview.cs
+++ b/_atom/RepoUtils/IWaitForCopilotReview.cs
@@ -1,0 +1,74 @@
+namespace Atom.RepoUtils;
+
+/// <summary>
+///     Provides a build target that blocks until GitHub Copilot has finished reviewing a pull request.
+///     This fills the gap where GitHub cannot natively wait for a Copilot review before completing an
+///     auto-merge, allowing the target to be sequenced ahead of an auto-merge step.
+/// </summary>
+internal interface IWaitForCopilotReview : ICopilotReviewHelper, IPullRequestHelper, IGithubHelper
+{
+    /// <summary>
+    ///     The login of the Copilot reviewer bot to wait for. Defaults to
+    ///     <see cref="ICopilotReviewHelper.DefaultCopilotReviewerLogin" />.
+    /// </summary>
+    [ParamDefinition("copilot-reviewer-login", "The login of the Copilot reviewer bot to wait for.")]
+    string CopilotReviewerLogin => GetParam(() => CopilotReviewerLogin, DefaultCopilotReviewerLogin);
+
+    /// <summary>
+    ///     The maximum amount of time, in seconds, to wait for Copilot to finish reviewing before failing
+    ///     the target. Defaults to 600 seconds (10 minutes).
+    /// </summary>
+    [ParamDefinition("copilot-review-timeout-seconds",
+        "Maximum time in seconds to wait for Copilot to finish reviewing.")]
+    int CopilotReviewTimeoutSeconds => GetParam(() => CopilotReviewTimeoutSeconds, 600);
+
+    /// <summary>
+    ///     The delay, in seconds, between successive polls of the pull request's review state. Defaults to
+    ///     15 seconds.
+    /// </summary>
+    [ParamDefinition("copilot-review-poll-interval-seconds",
+        "Polling interval in seconds while waiting for Copilot to finish reviewing.")]
+    int CopilotReviewPollIntervalSeconds => GetParam(() => CopilotReviewPollIntervalSeconds, 15);
+
+    /// <summary>
+    ///     An optional GitHub personal access token used to read the Copilot review state. When not
+    ///     supplied, the default <see cref="IGithubHelper.GithubToken" /> is used instead. A dedicated PAT
+    ///     can be provided for cases where the default workflow token cannot read the review state (for
+    ///     example on some Dependabot-created pull requests).
+    /// </summary>
+    [SecretDefinition("copilot-review-token",
+        "Optional GitHub PAT used to read Copilot review state; falls back to the default GitHub token.")]
+    string? CopilotReviewToken => GetParam(() => CopilotReviewToken);
+
+    /// <summary>
+    ///     Waits until Copilot has finished reviewing the target pull request. The target succeeds
+    ///     immediately when Copilot was not requested as a reviewer, and fails when Copilot does not
+    ///     finish reviewing within the configured timeout.
+    /// </summary>
+    Target WaitForCopilotReview =>
+        t => t
+            .RequiresParam(nameof(PullRequestNumber))
+            .UsesParam(nameof(CopilotReviewerLogin))
+            .UsesParam(nameof(GithubToken))
+            .UsesParam(nameof(CopilotReviewTimeoutSeconds))
+            .UsesParam(nameof(CopilotReviewPollIntervalSeconds))
+            .UsesParam(nameof(CopilotReviewToken))
+            .Executes(async cancellationToken =>
+            {
+                // Prefer the dedicated PAT when supplied, otherwise fall back to the default token.
+                var token = string.IsNullOrWhiteSpace(CopilotReviewToken)
+                    ? GithubToken
+                    : CopilotReviewToken;
+
+                if (string.IsNullOrWhiteSpace(token))
+                    throw new StepFailedException(
+                        $"A GitHub token is required. Provide '{nameof(GithubToken)}' or '{nameof(CopilotReviewToken)}'.");
+
+                await WaitForCopilotReviewToComplete(PullRequestNumber,
+                    token,
+                    CopilotReviewerLogin,
+                    TimeSpan.FromSeconds(CopilotReviewTimeoutSeconds),
+                    TimeSpan.FromSeconds(CopilotReviewPollIntervalSeconds),
+                    cancellationToken);
+            });
+}

--- a/_atom/Targets/IDocTargets.cs
+++ b/_atom/Targets/IDocTargets.cs
@@ -1,236 +1,29 @@
-using LogLevel = Microsoft.Extensions.Logging.LogLevel;
-
 namespace Atom.Targets;
 
-internal interface IDocTargets : IDotnetCliHelper, IGithubHelper, ISetupBuildInfo
+internal interface IDocTargets : IDocFxHelper
 {
-    private const string GeneratedDocsArtifactName = "GeneratedDocs";
-
     Target BuildDocs =>
         t => t
-            .DescribedAs("Generates API documentation using DocFX")
+            .DescribedAs("Builds the DocFX documentation.")
             .ProducesArtifact(GeneratedDocsArtifactName)
-            .Executes(async cancellationToken =>
-            {
-                // First, build analyzers in release mode
-                await DotnetCli.Build([RootedFileSystem.GetPath<Projects.Invex_Atom_Build_Analyzers>()],
-                    new()
-                    {
-                        Configuration = "Release",
-                    },
-                    cancellationToken: cancellationToken);
-
-                await DotnetCli.Build([RootedFileSystem.GetPath<Projects.Invex_Atom_Build_SourceGenerators>()],
-                    new()
-                    {
-                        Configuration = "Release",
-                    },
-                    cancellationToken: cancellationToken);
-
-                var siteDirectory = RootedFileSystem.AtomRootDirectory / "_site";
-
-                // If .NET 10, we can just do dotnet tool exec docfx
-                if (RuntimeInformation.FrameworkDescription.StartsWith(".NET 10"))
-                {
-                    await ProcessRunner.RunAsync(new("dotnet", "tool exec -y docfx")
-                        {
-                            WorkingDirectory = RootedFileSystem.AtomRootDirectory,
-                        },
-                        cancellationToken);
-                }
-                else
-                {
-                    // Otherwise, we need to restore the tools and run docfx
-                    Logger.LogInformation("Acquiring DocFX tool...");
-
-                    await ProcessRunner.RunAsync(new("dotnet", "tool update docfx -g")
-                        {
-                            WorkingDirectory = RootedFileSystem.AtomRootDirectory,
-                        },
-                        cancellationToken);
-
-                    Logger.LogInformation("Running DocFX...");
-
-                    await ProcessRunner.RunAsync(new("dotnet", "docfx")
-                        {
-                            WorkingDirectory = RootedFileSystem.AtomRootDirectory,
-                        },
-                        cancellationToken);
-                }
-
-                Logger.LogInformation("DocFX site generated at {Path}", siteDirectory);
-
-                // Copy the generated site to the publish directory
-                await CopyDirectory(siteDirectory, RootedFileSystem.AtomPublishDirectory / GeneratedDocsArtifactName);
-            });
+            .Executes(cancellationToken => BuildDocFxDocs([
+                    Projects.Invex_Atom_Build_Analyzers.Path(RootedFileSystem),
+                    Projects.Invex_Atom_Build_SourceGenerators.Path(RootedFileSystem),
+                ],
+                cancellationToken));
 
     Target ServeDocs =>
         t => t
-            .DescribedAs("Builds and serves the DocFX documentation site locally")
-            .DependsOn(BuildDocs)
-            .ConsumesArtifact(nameof(BuildDocs), GeneratedDocsArtifactName)
-            .Executes(async cancellationToken =>
-            {
-                Logger.LogInformation("Serving DocFX site at http://localhost:8080/README.html");
-                Logger.LogInformation("Press Ctrl+C to stop the server.");
-
-                try
-                {
-                    await ProcessRunner.RunAsync(new("dotnet", "docfx serve _site --port 8080")
-                        {
-                            WorkingDirectory = RootedFileSystem.AtomRootDirectory,
-                        },
-                        cancellationToken);
-                }
-                catch (TaskCanceledException)
-                {
-                    Logger.LogInformation("DocFX server stopped.");
-                }
-            });
+            .DescribedAs("Serves the DocFX documentation.")
+            .DependsOn(nameof(BuildDocs))
+            .Executes(ServeDocFxDocs);
 
     Target PublishDocs =>
         t => t
-            .DescribedAs("Publishes the generated DocFX site to GitHub Pages via the gh-pages branch")
+            .DescribedAs("Publishes the DocFX documentation to Github Pages.")
             .RequiresParam(nameof(GithubToken))
-            .DependsOn(BuildDocs)
-            .DependsOn(SetupBuildInfo)
             .ConsumesArtifact(nameof(BuildDocs), GeneratedDocsArtifactName)
-            .Executes(async cancellationToken =>
-            {
-                var siteArtifact = RootedFileSystem.AtomArtifactsDirectory / GeneratedDocsArtifactName;
-
-                if (!RootedFileSystem.Directory.Exists(siteArtifact))
-                    throw new StepFailedException("Site directory '_site' does not exist. Run BuildDocs first.");
-
-                // Create a fresh temporary directory for the gh-pages checkout
-                var tempDir = RootedFileSystem.AtomTempDirectory / "gh-pages-temp";
-
-                if (RootedFileSystem.Directory.Exists(tempDir))
-                    ForceDeleteDirectory(tempDir);
-
-                RootedFileSystem.Directory.CreateDirectory(tempDir);
-
-                try
-                {
-                    // Init a fresh repo
-                    await ProcessRunner.RunAsync(new("git", "init")
-                        {
-                            WorkingDirectory = tempDir,
-                        },
-                        cancellationToken);
-
-                    await ProcessRunner.RunAsync(new("git", "checkout --orphan gh-pages")
-                        {
-                            WorkingDirectory = tempDir,
-                        },
-                        cancellationToken);
-
-                    // Set git user details for the commit
-                    await ProcessRunner.RunAsync(new("git", ["config", "user.name", "\"github-actions[bot]\""])
-                        {
-                            WorkingDirectory = tempDir,
-                        },
-                        cancellationToken);
-
-                    await ProcessRunner.RunAsync(new("git",
-                            ["config", "user.email", "\"41898282+github-actions[bot]@users.noreply.github.com\""])
-                        {
-                            WorkingDirectory = tempDir,
-                        },
-                        cancellationToken);
-
-                    // Copy the generated site to the gh-pages branch
-                    await CopyDirectory(siteArtifact, tempDir);
-
-                    // Commit
-                    await ProcessRunner.RunAsync(new("git", "add .")
-                        {
-                            WorkingDirectory = tempDir,
-                        },
-                        cancellationToken);
-
-                    await ProcessRunner.RunAsync(
-                        new("git", ["commit", "-m", "\"Deploy documentation to GitHub Pages\""])
-                        {
-                            WorkingDirectory = tempDir,
-                        },
-                        cancellationToken);
-
-                    // Get the remote URL from the main repo
-                    var remoteResult = await ProcessRunner.RunAsync(new("git", "remote get-url origin")
-                        {
-                            WorkingDirectory = RootedFileSystem.AtomRootDirectory,
-                            OutputLogLevel = LogLevel.Debug,
-                        },
-                        cancellationToken);
-
-                    var remoteUrl = remoteResult.Output.Trim();
-
-                    if (string.IsNullOrEmpty(remoteUrl))
-                        throw new StepFailedException("Could not determine git remote URL.");
-
-                    // Inject the GitHub token into the remote URL for authentication
-                    if (!string.IsNullOrEmpty(GithubToken) && remoteUrl.StartsWith("https://"))
-                        remoteUrl = remoteUrl.Replace("https://", $"https://x-access-token:{GithubToken}@");
-
-                    // Force push to gh-pages
-                    Logger.LogInformation("Pushing to gh-pages branch...");
-
-                    await ProcessRunner.RunAsync(new("git", ["push", "--force", remoteUrl, "gh-pages"])
-                        {
-                            WorkingDirectory = tempDir,
-                        },
-                        cancellationToken);
-
-                    Logger.LogInformation("Documentation published to GitHub Pages successfully.");
-                }
-                finally
-                {
-                    // Cleanup
-                    if (RootedFileSystem.Directory.Exists(tempDir))
-                        ForceDeleteDirectory(tempDir);
-                }
-            });
-
-    /// <summary>
-    ///     Copies all files and subdirectories from a source directory to a destination directory.
-    /// </summary>
-    /// <param name="sourceDirectory">The source directory.</param>
-    /// <param name="destinationDirectory">The destination directory.</param>
-    async Task CopyDirectory(RootedPath sourceDirectory, RootedPath destinationDirectory)
-    {
-        // Ensure the destination directory exists
-        RootedFileSystem.Directory.CreateDirectory(destinationDirectory);
-
-        // Copy all files
-        foreach (var file in RootedFileSystem
-                     .Directory
-                     .GetFiles(sourceDirectory)
-                     .Select(RootedFileSystem.CreateRootedPath))
-            RootedFileSystem.File.Copy(file, destinationDirectory / RootedFileSystem.Path.GetFileName(file), true);
-
-        // Recursively copy all subdirectories
-        foreach (var directory in RootedFileSystem
-                     .Directory
-                     .GetDirectories(sourceDirectory)
-                     .Select(RootedFileSystem.CreateRootedPath))
-            await CopyDirectory(directory, destinationDirectory / RootedFileSystem.Path.GetFileName(directory));
-    }
-
-    /// <summary>
-    ///     Recursively removes read-only attributes and deletes a directory.
-    ///     Git object files are marked read-only, so a plain Directory.Delete fails.
-    /// </summary>
-    void ForceDeleteDirectory(string path)
-    {
-        foreach (var file in RootedFileSystem.Directory.GetFiles(path, "*", SearchOption.AllDirectories))
-        {
-            var attrs = RootedFileSystem.File.GetAttributes(file);
-
-            if (attrs.HasFlag(FileAttributes.ReadOnly))
-                RootedFileSystem.File.SetAttributes(file, attrs & ~FileAttributes.ReadOnly);
-        }
-
-        RootedFileSystem.Directory.Delete(path, true);
-    }
+            .DependsOn(nameof(SetupBuildInfo))
+            .Executes(cancellationToken =>
+                PublishDocFxDocsToGithub(GithubToken, GeneratedDocsArtifactName, cancellationToken));
 }

--- a/_atom/_atom.csproj
+++ b/_atom/_atom.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
     <PackageReference Include="Octokit.GraphQL" Version="0.4.0-beta" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>

--- a/_atom/_usings.cs
+++ b/_atom/_usings.cs
@@ -1,4 +1,5 @@
 global using System.Runtime.InteropServices;
+global using Atom.RepoUtils;
 global using Atom.Targets;
 global using Invex.Atom.Build;
 global using Invex.Atom.Build.BuildOptions;

--- a/src/Invex.Atom.Build/Invex.Atom.Build.csproj
+++ b/src/Invex.Atom.Build/Invex.Atom.Build.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.FileSystem" Version="0.1.0" />
-    <PackageReference Include="Invex.Process" Version="0.2.0" />
-    <PackageReference Include="Invex.SemanticVersion" Version="0.2.0" />
+    <PackageReference Include="Invex.FileSystem" Version="1.0.0" />
+    <PackageReference Include="Invex.Process" Version="1.0.0" />
+    <PackageReference Include="Invex.SemanticVersion" Version="1.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     <PackageReference Include="Spectre.Console" Version="0.56.0" />
     <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
   </ItemGroup>

--- a/src/Invex.Atom.Build/Invex.Atom.Build.csproj
+++ b/src/Invex.Atom.Build/Invex.Atom.Build.csproj
@@ -17,7 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.Analyzers.PublicApiSurface" Version="0.1.0" PrivateAssets="all" />
+
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Invex.Atom.Module.AzureKeyVault/Invex.Atom.Module.AzureKeyVault.csproj
+++ b/src/Invex.Atom.Module.AzureKeyVault/Invex.Atom.Module.AzureKeyVault.csproj
@@ -10,7 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.Analyzers.PublicApiSurface" Version="0.1.0" PrivateAssets="all" />
+
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Invex.Atom.Module.AzureStorage/Invex.Atom.Module.AzureStorage.csproj
+++ b/src/Invex.Atom.Module.AzureStorage/Invex.Atom.Module.AzureStorage.csproj
@@ -7,7 +7,11 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.0" />
-    <PackageReference Include="Invex.Analyzers.PublicApiSurface" Version="0.1.0" PrivateAssets="all" />
+
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="MimeTypes" Version="2.5.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Invex.Atom.Module.DevopsWorkflows/Invex.Atom.Module.DevopsWorkflows.csproj
+++ b/src/Invex.Atom.Module.DevopsWorkflows/Invex.Atom.Module.DevopsWorkflows.csproj
@@ -9,7 +9,11 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Invex.Analyzers.PublicApiSurface" Version="0.1.0" PrivateAssets="all" />
+
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Invex.Atom.Module.DevopsWorkflows/Invex.Atom.Module.DevopsWorkflows.csproj
+++ b/src/Invex.Atom.Module.DevopsWorkflows/Invex.Atom.Module.DevopsWorkflows.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.StructuredText.AzureDevopsPipelines" Version="0.3.0" />
+    <PackageReference Include="Invex.StructuredText.AzureDevopsPipelines" Version="1.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Invex.Atom.Module.Dotnet/Invex.Atom.Module.Dotnet.csproj
+++ b/src/Invex.Atom.Module.Dotnet/Invex.Atom.Module.Dotnet.csproj
@@ -6,7 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.Analyzers.PublicApiSurface" Version="0.1.0" PrivateAssets="all" />
+
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Invex.Atom.Module.GitVersion/Invex.Atom.Module.GitVersion.csproj
+++ b/src/Invex.Atom.Module.GitVersion/Invex.Atom.Module.GitVersion.csproj
@@ -5,7 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.Analyzers.PublicApiSurface" Version="0.1.0" PrivateAssets="all" />
+
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Invex.Atom.Module.GithubWorkflows/Invex.Atom.Module.GithubWorkflows.csproj
+++ b/src/Invex.Atom.Module.GithubWorkflows/Invex.Atom.Module.GithubWorkflows.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.StructuredText.GithubActions" Version="0.3.0" />
+    <PackageReference Include="Invex.StructuredText.GithubActions" Version="1.0.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 

--- a/src/Invex.Atom.Module.GithubWorkflows/Invex.Atom.Module.GithubWorkflows.csproj
+++ b/src/Invex.Atom.Module.GithubWorkflows/Invex.Atom.Module.GithubWorkflows.csproj
@@ -10,7 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.Analyzers.PublicApiSurface" Version="0.1.0" PrivateAssets="all" />
+
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Invex.Atom.Tool/Invex.Atom.Tool.csproj
+++ b/src/Invex.Atom.Tool/Invex.Atom.Tool.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/Invex.Atom.Workflows/Invex.Atom.Workflows.csproj
+++ b/src/Invex.Atom.Workflows/Invex.Atom.Workflows.csproj
@@ -5,7 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.Analyzers.PublicApiSurface" Version="0.1.0" PrivateAssets="all" />
+
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Invex.StructuredText" Version="1.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />

--- a/src/Invex.Atom.Workflows/Invex.Atom.Workflows.csproj
+++ b/src/Invex.Atom.Workflows/Invex.Atom.Workflows.csproj
@@ -6,11 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Invex.Analyzers.PublicApiSurface" Version="0.1.0" PrivateAssets="all" />
-    <PackageReference Include="Invex.StructuredText" Version="0.3.0" />
+    <PackageReference Include="Invex.StructuredText" Version="1.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Invex.Atom.Build.Analyzers.Tests/Invex.Atom.Build.Analyzers.Tests.csproj
+++ b/tests/Invex.Atom.Build.Analyzers.Tests/Invex.Atom.Build.Analyzers.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="10.0.8" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.9" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Invex.Atom.Build.SourceGenerators.Tests/Invex.Atom.Build.SourceGenerators.Tests.csproj
+++ b/tests/Invex.Atom.Build.SourceGenerators.Tests/Invex.Atom.Build.SourceGenerators.Tests.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="10.0.8" />
-    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.9" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Build.Tests/Invex.Atom.Build.Tests.csproj
+++ b/tests/Invex.Atom.Build.Tests/Invex.Atom.Build.Tests.csproj
@@ -12,14 +12,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.56.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Module.DevopsWorkflows.Tests/Invex.Atom.Module.DevopsWorkflows.Tests.csproj
+++ b/tests/Invex.Atom.Module.DevopsWorkflows.Tests/Invex.Atom.Module.DevopsWorkflows.Tests.csproj
@@ -12,14 +12,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.56.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Module.GithubWorkflows.Tests/Invex.Atom.Module.GithubWorkflows.Tests.csproj
+++ b/tests/Invex.Atom.Module.GithubWorkflows.Tests/Invex.Atom.Module.GithubWorkflows.Tests.csproj
@@ -12,14 +12,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.56.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.TestUtils/Invex.Atom.TestUtils.csproj
+++ b/tests/Invex.Atom.TestUtils/Invex.Atom.TestUtils.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.56.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
   </ItemGroup>

--- a/tests/Invex.Atom.Tool.Tests/Invex.Atom.Tool.Tests.csproj
+++ b/tests/Invex.Atom.Tool.Tests/Invex.Atom.Tool.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Workflows.Tests/Invex.Atom.Workflows.Tests.csproj
+++ b/tests/Invex.Atom.Workflows.Tests/Invex.Atom.Workflows.Tests.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.56.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.19.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.19.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request introduces a new workflow step and supporting code to ensure that GitHub Copilot has completed its review before continuing with pull request validation. It also refactors several internal interfaces for improved encapsulation and organization. The most important changes are summarized below:

**Copilot Review Integration:**

* Added a new `WaitForCopilotReview` job to the `Validate.yml` workflow, which runs a step to block until Copilot has finished reviewing a pull request. This helps ensure that Copilot feedback is always considered before merging.
* Introduced a new `ICopilotReviewHelper` interface in `Atom.RepoUtils` with an implementation for polling the GitHub API to wait for Copilot's review to complete, including robust handling of review state and timeouts.
* Updated the main build interface `IBuild` to include `IWaitForCopilotReview` and registered the new workflow step, passing necessary secrets and parameters. [[1]](diffhunk://#diff-7775cbaf97fc58eb8718a8411222ca9c9d187010dac02a23253f93499acd5f67L16-R17) [[2]](diffhunk://#diff-7775cbaf97fc58eb8718a8411222ca9c9d187010dac02a23253f93499acd5f67R118-R126)

**Internal Interface Refactoring:**

* Moved and made internal several interfaces and records (`IApiSurfaceHelper`, `IApproveDependabotPr`, `ICheckPrForBreakingChanges`, and related types), relocating them from `Atom.Targets` to `Atom.RepoUtils` and restricting their visibility for better encapsulation. [[1]](diffhunk://#diff-af827d38b51b759a68694590e2553f7e73edeaa26efe869054ab33f00d0817b3L1-R7) [[2]](diffhunk://#diff-faca346a9406688d7812f65a21f751fb064d79420410388424fea30044a9d1b1L1-R3) [[3]](diffhunk://#diff-fdf2510c74360f360db6f12116b7843d076f32bbba262ff890b0d48a6741a419L1-R5)

**Workflow Dependency Order:**

* Minor update to the `Build.yml` workflow to reorder the dependencies for the `PublishDocs` job, ensuring `SetupBuildInfo` runs before `BuildDocs` as needed.