### PR TITLE
fix(atom): inject Dependabot PAT for auto-merge workflow

### DIFF
--- a/.github/workflows/Dependabot Enable auto-merge.yml
+++ b/.github/workflows/Dependabot Enable auto-merge.yml
@@ -31,5 +31,6 @@ jobs:
         id: ApproveDependabotPr
         run: dotnet run --project _atom/_atom.csproj -- ApproveDependabotPr --skip --headless
         env:
+          dependabot-enable-auto-merge-pat: ${{ secrets.DEPENDABOT_ENABLE_AUTO_MERGE_PAT }}
           pull-request-number: ${{ github.event.number }}
 

--- a/_atom/IBuild.cs
+++ b/_atom/IBuild.cs
@@ -306,6 +306,7 @@ internal interface IBuild : IWorkflowBuildDefinition,
                     Options =
                     [
                         BuildOptions.Inject.Secret(nameof(GithubToken)),
+                        BuildOptions.Inject.Secret(nameof(DependabotEnableAutoMergePat)),
                         BuildOptions.Inject.Param(nameof(PullRequestNumber),
                             TextExpressions.Github.GithubEvent["number"]),
                         BuildOptions.Target.RunIfWorkflowCondition(


### PR DESCRIPTION
Added `DependabotEnableAutoMergePat` secret injection to `_atom` build options and updated the GitHub workflow to pass the PAT as an environment variable. This allows Dependabot to enable auto-merge functionality for its pull requests.