### PR TITLE
fix: use unique writer per devops pipeline file

### DIFF
--- a/src/Invex.Atom.Module.DevopsWorkflows/Workflows/Devops/DevopsWorkflowFileWriter.cs
+++ b/src/Invex.Atom.Module.DevopsWorkflows/Workflows/Devops/DevopsWorkflowFileWriter.cs
@@ -7,7 +7,6 @@ internal sealed class DevopsWorkflowFileWriter(
 ) : WorkflowFileWriter<DevopsWorkflowType>(fileSystem, logger)
 {
     private readonly IRootedFileSystem _fileSystem = fileSystem;
-    private readonly DevopsPipelineWriter _pipelineWriter = new();
 
     protected override string FileExtension => "yml";
 
@@ -16,8 +15,10 @@ internal sealed class DevopsWorkflowFileWriter(
     protected override string WriteWorkflow(WorkflowModel workflow)
     {
         var devopsPipeline = workflowBuilder.Build(workflow);
-        _pipelineWriter.Write(devopsPipeline);
 
-        return _pipelineWriter.TextWriter.ToString();
+        var writer = new DevopsPipelineWriter();
+        writer.Write(devopsPipeline);
+
+        return writer.TextWriter.ToString();
     }
 }


### PR DESCRIPTION
This pull request refactors the way `DevopsPipelineWriter` is used in the `DevopsWorkflowFileWriter` class. The main change is to create a new instance of `DevopsPipelineWriter` each time a workflow is written, instead of reusing a single instance. This helps prevent potential issues with state being shared across multiple workflow writes.

Refactoring of pipeline writer usage:

* Removed the private field `_pipelineWriter` from `DevopsWorkflowFileWriter` and replaced it with a new local instance in the `WriteWorkflow` method to avoid shared state.
* Updated the `WriteWorkflow` method to instantiate a new `DevopsPipelineWriter` for each call, ensuring that each workflow write operation uses a fresh writer.