### PR TITLE
fix: update structuredtext package to resolve property line splittingissue

### DIFF
--- a/src/Invex.Atom.Module.DevopsWorkflows/Invex.Atom.Module.DevopsWorkflows.csproj
+++ b/src/Invex.Atom.Module.DevopsWorkflows/Invex.Atom.Module.DevopsWorkflows.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.StructuredText.AzureDevopsPipelines" Version="1.0.0" />
+    <PackageReference Include="Invex.StructuredText.AzureDevopsPipelines" Version="1.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Invex.Atom.Module.GithubWorkflows/Invex.Atom.Module.GithubWorkflows.csproj
+++ b/src/Invex.Atom.Module.GithubWorkflows/Invex.Atom.Module.GithubWorkflows.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.StructuredText.GithubActions" Version="1.0.0" />
+    <PackageReference Include="Invex.StructuredText.GithubActions" Version="1.1.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 

--- a/src/Invex.Atom.Workflows/Invex.Atom.Workflows.csproj
+++ b/src/Invex.Atom.Workflows/Invex.Atom.Workflows.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Invex.StructuredText" Version="1.0.0" />
+    <PackageReference Include="Invex.StructuredText" Version="1.1.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />


### PR DESCRIPTION
This pull request updates dependencies across several projects to use the latest versions of the `Invex.StructuredText` packages. These updates ensure compatibility with new features and bug fixes provided in the 1.1.0 releases.

Dependency version updates:

* Updated `Invex.StructuredText.AzureDevopsPipelines` from version 1.0.0 to 1.1.0 in `Invex.Atom.Module.DevopsWorkflows.csproj`
* Updated `Invex.StructuredText.GithubActions` from version 1.0.0 to 1.1.0 in `Invex.Atom.Module.GithubWorkflows.csproj`
* Updated `Invex.StructuredText` from version 1.0.0 to 1.1.0 in `Invex.Atom.Workflows.csproj`