### PR TITLE
feat(build): schedule dependabot for 12am monday AEST

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+      day: monday
+      time: "00:00"
+      timezone: Australia/Brisbane
     groups:
       nuget-deps:
         patterns: [ "*" ]

--- a/_atom/IBuild.cs
+++ b/_atom/IBuild.cs
@@ -290,6 +290,9 @@ internal interface IBuild : IWorkflowBuildDefinition,
                     Schedule = new()
                     {
                         Interval = ScheduleInterval.Daily,
+                        Day = ScheduleDay.Monday,
+                        Time = "00:00",
+                        Timezone = "Australia/Brisbane",
                     },
                     TargetBranch = "main",
                     OpenPullRequestsLimit = 10,


### PR DESCRIPTION
This pull request updates the dependency update schedules to provide more precise control over when updates are performed. The main changes involve specifying the day, time, and timezone for scheduled updates in both the Dependabot configuration and internal build interface.

**Dependency update scheduling:**

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R13-R15): Added `day` (Monday), `time` ("00:00"), and `timezone` ("Australia/Brisbane") fields to the update schedule configuration to ensure updates run at a consistent, predictable time.
* [`_atom/IBuild.cs`](diffhunk://#diff-7775cbaf97fc58eb8718a8411222ca9c9d187010dac02a23253f93499acd5f67R293-R295): Updated the `Schedule` object to explicitly set the day, time, and timezone for dependency update jobs, mirroring the configuration in the YAML file.