### PR TITLE
fix(dependabot): adjust schedule to weekly with specific timezone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
   - package-ecosystem: nuget
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: saturday
+      time: "00:00"
+      timezone: Australia/Brisbane
     groups:
       nuget-deps:
         patterns: [ "*" ]

--- a/_atom/IBuild.cs
+++ b/_atom/IBuild.cs
@@ -289,7 +289,10 @@ internal interface IBuild : IWorkflowBuildDefinition,
                     },
                     Schedule = new()
                     {
-                        Interval = ScheduleInterval.Daily,
+                        Interval = ScheduleInterval.Weekly,
+                        Day = ScheduleDay.Saturday,
+                        Time = "00:00",
+                        Timezone = "Australia/Brisbane",
                     },
                     TargetBranch = "main",
                     OpenPullRequestsLimit = 10,


### PR DESCRIPTION
This pull request updates the scheduling configuration for automated dependency updates and build workflows, changing them from a daily schedule to a weekly schedule on Saturdays at midnight, in the Australia/Brisbane timezone.

**Scheduling changes:**

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-R15): Changed the `nuget` dependency update schedule from daily to weekly, specifying updates to run on Saturdays at 00:00 in the Australia/Brisbane timezone.
* [`_atom/IBuild.cs`](diffhunk://#diff-7775cbaf97fc58eb8718a8411222ca9c9d187010dac02a23253f93499acd5f67L292-R295): Updated the `Schedule` configuration for builds to run weekly on Saturdays at 00:00, also in the Australia/Brisbane timezone.