### PR TITLE
chore: bump deps and update license expression

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageDescription>An opinionated task and build automation framework</PackageDescription>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Invex.Atom.Build/Invex.Atom.Build.csproj
+++ b/src/Invex.Atom.Build/Invex.Atom.Build.csproj
@@ -5,20 +5,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.FileSystem" Version="1.1.0" />
-    <PackageReference Include="Invex.Process" Version="1.1.0" />
-    <PackageReference Include="Invex.SemanticVersion" Version="1.1.0" />
+    <PackageReference Include="Invex.FileSystem" Version="1.2.0" />
+    <PackageReference Include="Invex.Process" Version="1.2.0" />
+    <PackageReference Include="Invex.SemanticVersion" Version="1.2.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     <PackageReference Include="Spectre.Console" Version="0.57.2" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
   </ItemGroup>
 
   <ItemGroup>
-
-    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.6.0">
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Invex.Atom.Module.AzureKeyVault/Invex.Atom.Module.AzureKeyVault.csproj
+++ b/src/Invex.Atom.Module.AzureKeyVault/Invex.Atom.Module.AzureKeyVault.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.6.0">
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Invex.Atom.Module.AzureStorage/Invex.Atom.Module.AzureStorage.csproj
+++ b/src/Invex.Atom.Module.AzureStorage/Invex.Atom.Module.AzureStorage.csproj
@@ -7,12 +7,14 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
-
-    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.6.0">
+    <PackageReference Include="MimeTypes" Version="2.5.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MimeTypes" Version="2.5.2">
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Invex.Atom.Module.DevopsWorkflows/Invex.Atom.Module.DevopsWorkflows.csproj
+++ b/src/Invex.Atom.Module.DevopsWorkflows/Invex.Atom.Module.DevopsWorkflows.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.StructuredText.AzureDevopsPipelines" Version="1.2.0" />
+    <PackageReference Include="Invex.StructuredText.AzureDevopsPipelines" Version="1.3.0" />
   </ItemGroup>
   
   <ItemGroup>
 
-    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.6.0">
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Invex.Atom.Module.Dotnet/Invex.Atom.Module.Dotnet.csproj
+++ b/src/Invex.Atom.Module.Dotnet/Invex.Atom.Module.Dotnet.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.6.0">
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Invex.Atom.Module.GitVersion/Invex.Atom.Module.GitVersion.csproj
+++ b/src/Invex.Atom.Module.GitVersion/Invex.Atom.Module.GitVersion.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.6.0">
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Invex.Atom.Module.GithubWorkflows/Invex.Atom.Module.GithubWorkflows.csproj
+++ b/src/Invex.Atom.Module.GithubWorkflows/Invex.Atom.Module.GithubWorkflows.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Invex.StructuredText.GithubActions" Version="1.2.0" />
+    <PackageReference Include="Invex.StructuredText.GithubActions" Version="1.3.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 
   <ItemGroup>
 
-    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.6.0">
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Invex.Atom.Tool/Invex.Atom.Tool.csproj
+++ b/src/Invex.Atom.Tool/Invex.Atom.Tool.csproj
@@ -40,7 +40,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Invex.Atom.Workflows/Invex.Atom.Workflows.csproj
+++ b/src/Invex.Atom.Workflows/Invex.Atom.Workflows.csproj
@@ -5,16 +5,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-
-    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.6.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Invex.StructuredText" Version="1.2.0" />
+    <PackageReference Include="Invex.StructuredText" Version="1.3.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Spectre.Console" Version="0.57.2" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Invex.RepoUtils.PublicApiAnalyzers" Version="1.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -23,8 +27,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Spectre.Console" Version="0.57.2" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.1.1" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Analyzers" Version="2022.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Invex.Atom.Build.SourceGenerators.Tests/Invex.Atom.Build.SourceGenerators.Tests.csproj
+++ b/tests/Invex.Atom.Build.SourceGenerators.Tests/Invex.Atom.Build.SourceGenerators.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Formats.Asn1" Version="10.0.9" />
-    <PackageReference Include="Verify.NUnit" Version="31.22.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.24.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Build.Tests/Invex.Atom.Build.Tests.csproj
+++ b/tests/Invex.Atom.Build.Tests/Invex.Atom.Build.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.57.2" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.22.0" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.24.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Module.DevopsWorkflows.Tests/Invex.Atom.Module.DevopsWorkflows.Tests.csproj
+++ b/tests/Invex.Atom.Module.DevopsWorkflows.Tests/Invex.Atom.Module.DevopsWorkflows.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.57.2" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.22.0" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.24.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Module.Dotnet.Tests/Invex.Atom.Module.Dotnet.Tests.csproj
+++ b/tests/Invex.Atom.Module.Dotnet.Tests/Invex.Atom.Module.Dotnet.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.57.2" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Module.GithubWorkflows.Tests/Invex.Atom.Module.GithubWorkflows.Tests.csproj
+++ b/tests/Invex.Atom.Module.GithubWorkflows.Tests/Invex.Atom.Module.GithubWorkflows.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.57.2" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.22.0" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.24.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.TestUtils/Invex.Atom.TestUtils.csproj
+++ b/tests/Invex.Atom.TestUtils/Invex.Atom.TestUtils.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.57.2" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Tool.Tests/Invex.Atom.Tool.Tests.csproj
+++ b/tests/Invex.Atom.Tool.Tests/Invex.Atom.Tool.Tests.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.22.0" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.24.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Invex.Atom.Workflows.Tests/Invex.Atom.Workflows.Tests.csproj
+++ b/tests/Invex.Atom.Workflows.Tests/Invex.Atom.Workflows.Tests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.57.2" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Verify.NUnit" Version="31.22.0" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
+    <PackageReference Include="Verify.NUnit" Version="31.24.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates various package dependencies across the solution to their latest versions, improves package metadata, and makes minor project file organization changes. The main focus is on keeping dependencies up-to-date for bug fixes, security, and compatibility.

**Dependency updates:**

* Updated `Invex.FileSystem`, `Invex.Process`, and `Invex.SemanticVersion` dependencies to version 1.2.0, and `System.IO.Abstractions` to 22.2.0 in `Invex.Atom.Build.csproj`.
* Updated `Invex.StructuredText.AzureDevopsPipelines` and `Invex.StructuredText.GithubActions` to 1.3.0 in their respective module projects [[1]](diffhunk://#diff-81d8f9e2ce90b4e4835be7682d85422ead20d55d2880c504b4c8c1ff24d51dcbL10-R15) [[2]](diffhunk://#diff-3aa74d21d64048989630e92ccbc4d81c6e8e357e2e00c456b15fefc3ac76db4fL10-R16).
* Updated `Invex.StructuredText` to 1.3.0 and added `Spectre.Console` and `System.IO.Abstractions` 22.2.0 in `Invex.Atom.Workflows.csproj`.
* Updated `MimeTypes` and reorganized `Invex.RepoUtils.PublicApiAnalyzers` reference in `Invex.Atom.Module.AzureStorage.csproj`.

**Analyzer and test package updates:**

* Updated `Invex.RepoUtils.PublicApiAnalyzers` to 1.7.0 across all projects [[1]](diffhunk://#diff-35a9cd0447abd0eeddd5c256b84c4d75f5129a06b45c83e3810dc37e69c4c92cL8-R20) [[2]](diffhunk://#diff-828556ac35ce39c4010c306ff2959481394ef99bcadadfe148c57386c22deb5fL14-R14) [[3]](diffhunk://#diff-03b3a69f174c943718155e842eff9c9d3009f95c87838317ceb2589f6f168fc5L10-R17) [[4]](diffhunk://#diff-81d8f9e2ce90b4e4835be7682d85422ead20d55d2880c504b4c8c1ff24d51dcbL10-R15) [[5]](diffhunk://#diff-8af88b2315c38a2fe842d0b5d2fc9e7f7e1c2bc9bfeff759e3829126fa06a101L11-R11) [[6]](diffhunk://#diff-5411023872cd80e047abe67b4091c3a94dbe6f06a48075f61725a798892ae2d1L9-R9) [[7]](diffhunk://#diff-3aa74d21d64048989630e92ccbc4d81c6e8e357e2e00c456b15fefc3ac76db4fL10-R16) [[8]](diffhunk://#diff-576de78cb4bacfd75b21ec0a48304037691deb39d8d60ce01c507aebbd9abf09L8-R21).
* Updated `TestableIO.System.IO.Abstractions.TestingHelpers` to 22.2.0 and `Verify.NUnit` to 31.24.0 in all test projects [[1]](diffhunk://#diff-998338149182dd4f2095a9fc18edfcf883be079652593a0bb68c77423837b150L22-R23) [[2]](diffhunk://#diff-384e10485f96e3b9eedbb88d49c7eb0410201d7351eea5883bee4b425ee3421bL22-R23) [[3]](diffhunk://#diff-441f6a8948c5bdb01d4c9d2e6e46f12c106918c97d66d33eea51215186e433a4L20-R20) [[4]](diffhunk://#diff-3b961d499ef0b59f29892750308a634a9102d68690c3cd487b2cd837a00f5ea1L22-R23) [[5]](diffhunk://#diff-118cc043868220d987522c529f76f956e608a68b8be7b4ece32c8077bd159a6dL11-R11) [[6]](diffhunk://#diff-28ac8974d7753042db579f41170faa2d74b2c4cc6cceba5d8d18a3775f4195a4L19-R20) [[7]](diffhunk://#diff-4ff0b95c8da51e58cd87dd7f6d2f4d5fb83a9e66fa5955132c0c8d3a0bd1f0f3L18-R19) [[8]](diffhunk://#diff-0315e81fd9d38e6944f210903686cfdf57e7086814be117c188fb0797ebaa3f0L18-R18).

**Project metadata improvements:**

* Changed from using a license file to a `PackageLicenseExpression` (MIT) in `Directory.Build.props` for improved NuGet compliance.

**Project file organization:**

* Reorganized `ItemGroup` sections in `.csproj` files for better clarity and separation of analyzer dependencies [[1]](diffhunk://#diff-03b3a69f174c943718155e842eff9c9d3009f95c87838317ceb2589f6f168fc5L10-R17) [[2]](diffhunk://#diff-576de78cb4bacfd75b21ec0a48304037691deb39d8d60ce01c507aebbd9abf09L8-R21).

These changes ensure that all projects and tests use the latest stable dependencies and analyzers, improving reliability and maintainability.